### PR TITLE
feat: CustomAuthenticationFilter생성

### DIFF
--- a/backend/src/main/java/com/back/global/rq/Rq.java
+++ b/backend/src/main/java/com/back/global/rq/Rq.java
@@ -1,0 +1,35 @@
+package com.back.global.rq;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class Rq {
+    private final HttpServletRequest req;
+    private final HttpServletResponse resp;
+
+    public String getHeader(String name, String defaultValue) {
+        return Optional.ofNullable(req.getHeader(name))
+                .filter(v -> !v.isBlank())
+                .orElse(defaultValue);
+    }
+
+
+    public String getCookieValue(String name, String defaultValue) {
+        return Optional.ofNullable(req.getCookies())
+                .flatMap(cookies -> Arrays.stream(cookies)
+                        .filter(c -> c.getName().equals(name))
+                        .map(Cookie::getValue)
+                        .filter(v -> !v.isBlank())
+                        .findFirst())
+                .orElse(defaultValue);
+    }
+
+}

--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -1,0 +1,114 @@
+package com.back.global.security;
+
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+import com.back.standard.util.Ut;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationFilter extends OncePerRequestFilter {
+    private final Rq rq;
+
+    @Value("${custom.jwt.secretKey}")
+    private String jwtSecret;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            work(request, response, filterChain);
+        } catch (ServiceException e) {
+            RsData<Void> rsData = e.getRsData();
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(rsData.statusCode());
+            response.getWriter().write(Ut.json.toString(rsData));
+        }
+    }
+
+    private void work(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        // 1) API 요청이 아닌 경우 패스
+        if (!request.getRequestURI().startsWith("/api/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2) 인증/인가가 필요없는 API 요청 패스 (TODO: 실제 경로로 수정)
+        if (List.of(
+                "/api/v1/member/login",
+                "/api/v1/member/logout",
+                "/api/v1/member/join"
+        ).contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 3) accessToken 추출(헤더 우선, 없으면 쿠키)
+        String accessToken;
+        String headerAuthorization = rq.getHeader("Authorization", "");
+
+        if (!headerAuthorization.isBlank()) {
+            if (!headerAuthorization.startsWith("Bearer "))
+                throw new ServiceException("401-2", "Authorization 헤더가 Bearer 형식이 아닙니다.");
+
+            accessToken = headerAuthorization.substring("Bearer ".length()).trim();
+        } else {
+            accessToken = rq.getCookieValue("accessToken", "");
+        }
+
+        // accessToken 없으면 통과(이후 SecurityConfig의 authenticated가 막을 것)
+        if (accessToken.isBlank()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 4) JWT 검증/파싱 (Claims)
+        Claims claims = Ut.jwt.payload(jwtSecret, accessToken);
+        if (claims == null) {
+            throw new ServiceException("401-1", "유효하지 않은 토큰입니다.");
+        }
+
+        // 5) SecurityContext 주입 (Member 엔티티 기준: id, loginid, email)
+        Long id = claims.get("id", Long.class);
+        String loginid = claims.get("loginid", String.class);
+        String email = claims.get("email", String.class);
+
+        if (id == null || loginid == null) {
+            throw new ServiceException("401-1", "토큰 클레임이 올바르지 않습니다.");
+        }
+
+        UserDetails user = new SecurityUser(
+                id,
+                loginid,
+                "",     // 토큰 인증에서는 비번 검증 안 함
+                email,
+                List.of() // 권한 없으면 빈 리스트
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities())
+        );
+
+        filterChain.doFilter(request, response);
+
+        // TODO(다음 단계): refresh(apiKey)로 사용자 조회 + accessToken 재발급
+    }
+}

--- a/backend/src/main/java/com/back/global/security/SecurityUser.java
+++ b/backend/src/main/java/com/back/global/security/SecurityUser.java
@@ -1,0 +1,23 @@
+package com.back.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class SecurityUser extends User {
+    private final Long id;
+    private final String email;
+
+    public SecurityUser(Long id,
+                        String loginId,
+                        String password,
+                        String email,
+                        Collection<? extends GrantedAuthority> authorities) {
+        super(loginId, password == null ? "" : password, authorities);
+        this.id = id;
+        this.email = email;
+    }
+}

--- a/backend/src/main/java/com/back/standard/util/Ut.java
+++ b/backend/src/main/java/com/back/standard/util/Ut.java
@@ -1,0 +1,52 @@
+package com.back.standard.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+public class Ut {
+
+    public static class jwt {
+        public static boolean isValid(String secret, String jwtStr) {
+            try {
+                SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+                Jwts.parser()
+                        .verifyWith(secretKey)
+                        .build()
+                        .parseSignedClaims(jwtStr);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        public static Claims payload(String secret, String jwtStr) {
+            try {
+                SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+                return Jwts.parser()
+                        .verifyWith(secretKey)
+                        .build()
+                        .parseSignedClaims(jwtStr)
+                        .getPayload();
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+    public static class json {
+        private static final ObjectMapper objectMapper = new ObjectMapper();
+
+        public static String toString(Object obj) {
+            try {
+                return objectMapper.writeValueAsString(obj);
+            } catch (Exception e) {
+                return "{\"resultCode\":\"500-1\",\"msg\":\"json serialize fail\"}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #11 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

	•	CustomAuthenticationFilter(OncePerRequestFilter) 추가
	•	/api/** 요청만 필터 적용
	•	인증 제외 URL(임시) 처리 (login/logout/join 등, TODO로 추후 수정 예정)
	•	accessToken 탐색 우선순위 구현
	•	Authorization 헤더 Bearer {token} 우선
	•	쿠키 accessToken fallback
	•	JWT 검증/파싱 후 Claims 추출
	•	SecurityContextHolder에 Authentication 주입
	•	SecurityUser 추가 (UserDetails 구현체)
	•	id, email 포함 / username은 loginid 사용
	•	Rq 유틸 추가(또는 최소 기능 구현)
	•	getHeader, getCookieValue 사용 가능
	•	(추후 재발급 단계 대비) setHeader, setCookie 포함
	•	Ut.jwt 유틸 추가/수정
	•	payload()가 Claims를 반환하도록 구현 (캐스팅 경고 제거)
	•	isValid() 유지(현재는 미사용)
	•	예외 처리
	•	ServiceException 발생 시 RsData를 JSON으로 응답

## 💬리뷰 요청사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.   
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?