### PR TITLE
refactor: Item - User 다대일 관계 매핑 설정

### DIFF
--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemCreateResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemCreateResponse.java
@@ -1,7 +1,6 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
 
@@ -27,7 +26,7 @@ public record ItemCreateResponse(
     public ItemCreateResponse(Item item) {
         this(
                 item.getId(),
-                item.getUserId(),
+                item.getUser().getId(),
                 item.getCategory().getId(),
                 item.getName(),
                 item.getImgUrl(),

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.java
@@ -17,7 +17,7 @@ public record ItemReplaceResponse(
     public ItemReplaceResponse(Item item) {
         this(
                 item.getId(),
-                item.getUserId(),
+                item.getUser().getId(),
                 item.getCategory().getId(),
                 item.getName(),
                 item.getImgUrl(),

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemResponse.java
@@ -1,7 +1,6 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -21,7 +20,7 @@ public record ItemResponse(
     public ItemResponse(Item item) {
         this(
                 item.getId(),
-                item.getUserId(),
+                item.getUser().getId(),
                 item.getCategory() == null ? null : item.getCategory().getId(),
                 item.getName(),
                 item.getImgUrl(),

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemUpdateResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemUpdateResponse.java
@@ -18,7 +18,7 @@ public record ItemUpdateResponse(
     public ItemUpdateResponse(Item item) {
         this(
                 item.getId(),
-                item.getUserId(),
+                item.getUser().getId(),
                 item.getCategory().getId(),
                 item.getName(),
                 item.getImgUrl(),

--- a/backend/src/main/java/com/back/domain/item/item/entity/Item.java
+++ b/backend/src/main/java/com/back/domain/item/item/entity/Item.java
@@ -1,6 +1,7 @@
 package com.back.domain.item.item.entity;
 
 import com.back.domain.category.category.entity.Category;
+import com.back.domain.user.user.entity.User;
 import com.back.global.exception.ServiceException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,8 +19,8 @@ public class Item {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: User 엔티티 추가 시 변경 예정
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY) // user(1) : item(N)
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY) // category(1) : item(N)
     private Category category;
@@ -37,7 +38,7 @@ public class Item {
     private Boolean isActive;
 
     public Item(
-            Long userId,
+            User user,
             Category category,
             String name,
             String imgUrl,
@@ -46,7 +47,7 @@ public class Item {
             LocalDate nextReplacementDate,
             Boolean isActive
     ) {
-        this.userId = userId;
+        this.user = user;
         this.category = category;
         this.name = name;
         this.imgUrl = imgUrl;
@@ -63,7 +64,7 @@ public class Item {
 
     //현재 요청자(actorUserId)가 이 Item의 소유자인지 확인
     public void validateOwner(Long actorUserId) {
-        if (!Objects.equals(this.userId, actorUserId)) {
+        if (!Objects.equals(this.user.getId(), actorUserId)) {
             throw new ServiceException("403-1", "%d번 아이템에 대한 권한이 없습니다.".formatted(this.id));
         }
     }

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -8,6 +8,8 @@ import com.back.domain.item.item.entity.Item;
 import com.back.domain.item.item.repository.ItemRepository;
 import com.back.domain.item.item.vo.CyclePeriod;
 import com.back.domain.item.itemHistory.service.ItemHistoryService;
+import com.back.domain.user.user.entity.User;
+import com.back.domain.user.user.service.UserService;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class ItemService {
+    private final UserService userService;
     private final ItemHistoryService itemHistoryService;
     private final ItemRepository itemRepository;
     private final CategoryRepository categoryRepository;
@@ -69,6 +72,12 @@ public class ItemService {
         return itemRepository.count();
     }
 
+    // userId로 User 조회
+    private User findUserOrThrow(Long userId) {
+        return userService.findById(userId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 유저입니다."));
+    }
+
     @Transactional
     public Item create(
             Long userId,
@@ -80,8 +89,9 @@ public class ItemService {
             LocalDate nextReplacementDate,
             Boolean isActive
     ) {
+        User user = findUserOrThrow(userId);
         Item item = new Item(
-                userId, category, name, imgUrl,
+                user, category, name, imgUrl,
                 startDate, cycleDays, nextReplacementDate, isActive
         );
 

--- a/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.java
+++ b/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.java
@@ -107,7 +107,7 @@ public class ItemControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("200"))
                 .andExpect(jsonPath("$.msg").value("아이템 수정 성공"))
                 .andExpect(jsonPath("$.data.id").value(item.getId()))
-                .andExpect(jsonPath("$.data.userId").value(item.getUserId()))
+                .andExpect(jsonPath("$.data.userId").value(item.getUser().getId()))
                 .andExpect(jsonPath("$.data.categoryId").value(item.getCategory().getId()))
                 .andExpect(jsonPath("$.data.name").value(item.getName()))
                 .andExpect(jsonPath("$.data.imgUrl").value(item.getImgUrl()))


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #51 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- Item 엔티티에서 userId를 @ManyToOne 관계의 User 타입으로 변경

## 💬리뷰 요청사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.   
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?