### PR TITLE
test: 아이템 등록 테스트

### DIFF
--- a/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.java
+++ b/backend/src/test/java/com/back/domain/item/item/controller/ItemControllerTest.java
@@ -4,11 +4,9 @@ import com.back.domain.item.item.entity.Item;
 import com.back.domain.item.item.service.ItemService;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
-import com.back.standard.util.Ut;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -18,7 +16,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -37,27 +34,8 @@ public class ItemControllerTest {
     @Autowired
     private UserService userService;
 
-    // application.yml 에서 주입받는 JWT 비밀키
-    @Value("${custom.jwt.secretKey}")
-    private String jwtSecret;
-
-    // AccessToken 만료 시간(초 단위)
-    @Value("${custom.accessToken.expirationSeconds}")
-    private int accessTokenExpirationSeconds;
-
-    /**
-     * 테스트용 Access Token 생성 메서드
-     * - 실제 로그인 과정을 거치지 않고
-     * - 컨트롤러 인증/인가 로직만 검증하기 위해 사용
-     */
-    private String generateAccessToken(Long userId, String loginId) {
-        // JWT Payload(claims)에 들어갈 사용자 정보
-        Map<String, Object> claims = Map.of(
-                "id", userId,
-                "loginId", loginId
-        );
-        // JWT 생성 (secretKey + 만료시간 + claims)
-        return Ut.jwt.toString(jwtSecret, accessTokenExpirationSeconds, claims);
+    private String getAuthHeader(User user) {
+        return "Bearer " + user.getApiKey();
     }
 
     @Test
@@ -251,14 +229,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 - 성공")
     void createItem_success() throws Exception {
-        // 인증이 필요한 API이므로, 테스트용 Access Token 생성
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -290,13 +267,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 - 월 단위 주기")
     void createItem_withMonthCycle() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 2,
@@ -322,13 +299,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 - 년 단위 주기")
     void createItem_withYearCycle() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 3,
@@ -353,13 +330,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - categoryId 누락")
     void createItem_missingCategoryId() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "name": "칫솔",
@@ -379,13 +356,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - name 누락")
     void createItem_missingName() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -405,13 +382,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - cycleDays 누락")
     void createItem_missingCycleDays() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -431,13 +408,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - 잘못된 cycleDays 형식")
     void createItem_invalidCycleDaysFormat() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -460,13 +437,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - 존재하지 않는 카테고리")
     void createItem_categoryNotFound() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 9999,
@@ -488,13 +465,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 실패 - cycleDays 값이 0 이하")
     void createItem_invalidCycleDaysValue() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -517,13 +494,13 @@ public class ItemControllerTest {
     @Test
     @DisplayName("아이템 등록 - imgUrl 없이 등록")
     void createItem_withoutImgUrl() throws Exception {
-        String accessToken = generateAccessToken(1L, "user1");
+        User user = userService.findById(1L).orElseThrow();
 
         ResultActions resultActions = mvc
                 .perform(
                         post("/api/v1/items")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Authorization", getAuthHeader(user))
                                 .content("""
                                         {
                                             "categoryId": 1,
@@ -542,6 +519,4 @@ public class ItemControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("201-1"))
                 .andExpect(jsonPath("$.data.imgUrl").isEmpty());
     }
-
-
 }


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 아이템 등록 API(POST /api/v1/items)에 대한 컨트롤러 테스트 작성
- 교체 주기(cycleDays)에 따른 다음 교체일 계산 로직을 단위별로 검증
- imgUrl이 없는 경우에도 정상 등록되는 시나리오를 추가
- 요청 값 검증 및 예외 케이스에 대한 테스트를 추가
  - 필수 값 누락 (categoryId, name, cycleDays)
  - cycleDays 형식 오류 (예: invalid)
  - cycleDays 값이 0 이하인 경우
  - 존재하지 않는 카테고리 ID 전달 시

## 💬리뷰 요청사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.   
-  cycleDays 파싱 및 날짜 계산 로직이 현재 요구사항(일/월/년 단위 교체 주기)에 맞게 테스트 케이스로 충분히 커버되었는지
- 실패 케이스에서 반환하는 resultCode 및 에러 메시지 수준이 API 응답 규칙에 맞는지