### PR TITLE
fix: 카테고리별 아이템 개수 조회 시 본인이 만든 아이템만 카운트

### DIFF
--- a/backend/src/main/java/com/back/domain/category/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/back/domain/category/category/controller/CategoryController.java
@@ -2,6 +2,8 @@ package com.back.domain.category.category.controller;
 
 import com.back.domain.category.category.dto.CategoryResponse;
 import com.back.domain.category.category.service.CategoryService;
+import com.back.domain.user.user.dto.UserDto;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,14 +20,17 @@ import java.util.List;
 @Tag(name = "CategoryController", description = "카테고리 컨트롤러")
 public class CategoryController {
     private final CategoryService categoryService;
+    private final Rq rq;
 
     @GetMapping
     @Operation(summary = "카테고리 조회")
     public RsData<List<CategoryResponse>> getCategories() {
+        UserDto actor = rq.getActor();
+
         return new RsData<>(
                 "200-1",
                 "카테고리 조회 성공",
-                categoryService.findAllWithItemCount()
+                categoryService.findAllWithItemCount(actor.id())
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/category/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/back/domain/category/category/repository/CategoryRepository.java
@@ -18,9 +18,9 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
                 c.id, c.name, count(i.id)
               )
               from Category c
-              left join Item i on i.category = c
+              left join Item i on i.category = c and i.user.id = :userId
               group by c.id, c.name
               order by c.id
             """)
-    List<CategoryResponse> findAllWithItemCount();
+    List<CategoryResponse> findAllWithItemCount(Long userId);
 }

--- a/backend/src/main/java/com/back/domain/category/category/service/CategoryService.java
+++ b/backend/src/main/java/com/back/domain/category/category/service/CategoryService.java
@@ -14,8 +14,8 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
-    public List<CategoryResponse> findAllWithItemCount() {
-        return categoryRepository.findAllWithItemCount();
+    public List<CategoryResponse> findAllWithItemCount(Long userId) {
+        return categoryRepository.findAllWithItemCount(userId);
     }
 
 }


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #171 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 카테고리별 아이템 개수 조회 시 본인이 만든 아이템만 카운트
- left join Item에서 조건에 userId 추가

## 💬리뷰 요청사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.   
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?