### PR TITLE
fix: Toast 알림이 상단바 아래에 표시되도록 위치 수정

### DIFF
--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -81,11 +81,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     setToasts((prev) => prev.filter((toast) => toast.id !== id));
   }, []);
 
-  /**
-   * 토스트 표시
-   * - 새로운 토스트 추가
-   * - 일정 시간 후 자동 제거
-   */
+  // 토스트 표시
   const showToast = useCallback(
     (type: ToastType, message: string, title?: string) => {
       const id = Date.now(); // 간단한 고유 ID 생성
@@ -106,7 +102,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       {children}
 
       <div
-        className="fixed top-4 right-4 flex flex-col items-end gap-2 pointer-events-none"
+        className="fixed top-20 right-4 flex flex-col items-end gap-2 pointer-events-none"
         style={{ zIndex: TOAST_Z_INDEX }}
         role="region"
         aria-label="알림"


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #184 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- Toast 컨테이너 클래스 수정
- top-4에서 top-20으로 변경
- 상단 헤더 아래에 Toast가 표시되도록 개선

<img width="643" height="159" alt="image" src="https://github.com/user-attachments/assets/93aca1a1-54f3-4384-9332-ea0bd5344696" />

## 💬리뷰 요청사항(선택)

- Toast 알림이 상단 헤더("POWER RANGERS" 로고)와 겹치지 않는지
- Toast가 화면 최상단에서 적절한 간격을 유지하는지
- 여러 Toast가 동시에 표시될 때 스택 형태로 정상 표시되는지
- Success, Error타입 Toast 모두 정상 표시되는지
- Toast 자동 사라짐(4초) 기능 정상 작동되는지
- 수동 닫기 버튼 정상 작동되는지