### PR TITLE
feat: 카테고리별 평균 사용 기간 통계 API 추가

### DIFF
--- a/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
+++ b/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
@@ -140,4 +140,18 @@ public class ItemController {
                 new ItemUpdateResponse(item)
         );
     }
+
+    @GetMapping("/statistics/category-average")
+    @Operation(summary = "카테고리별 평균 사용 기간 조회")
+    public RsData<List<CategoryAverageUsageResponse>> getCategoryAverageUsage() {
+        Long userId = rq.getMemberId();
+
+        List<CategoryAverageUsageResponse> data = itemService.getCategoryAverageUsage(userId);
+
+        return new RsData<>(
+                "200-1",
+                "카테고리별 평균 사용 기간 조회 성공",
+                data
+        );
+    }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/CategoryAverageUsageResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/CategoryAverageUsageResponse.java
@@ -1,0 +1,8 @@
+package com.back.domain.item.item.dto;
+
+public record CategoryAverageUsageResponse(
+        Long categoryId,
+        String categoryName,
+        Double averageUsageDays
+) {
+}

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -2,11 +2,13 @@ package com.back.domain.item.item.service;
 
 import com.back.domain.category.category.entity.Category;
 import com.back.domain.category.category.repository.CategoryRepository;
+import com.back.domain.item.item.dto.CategoryAverageUsageResponse;
 import com.back.domain.item.item.dto.ItemCreateRequest;
 import com.back.domain.item.item.dto.ItemUpdateRequest;
 import com.back.domain.item.item.entity.Item;
 import com.back.domain.item.item.repository.ItemRepository;
 import com.back.domain.item.item.vo.CyclePeriod;
+import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
 import com.back.domain.item.itemHistory.service.ItemHistoryService;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,6 +33,7 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final CategoryRepository categoryRepository;
     private final S3ImageService s3ImageService;
+    private final ItemHistoryRepository itemHistoryRepository;
 
     public Optional<Item> findById(Long id) {
         return itemRepository.findById(id);
@@ -229,5 +233,26 @@ public class ItemService {
         item.toggleActive();
 
         return item;
+    }
+
+    /**
+     * 특정 사용자의 카테고리별 평균 사용 기간 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryAverageUsageResponse> getCategoryAverageUsage(Long userId) {
+        // Repository에서 카테고리별 평균 사용 기간을 조회
+        List<Map<String, Object>> rawResults = itemHistoryRepository
+                .findAverageUsageDaysByCategoryForUser(userId);
+
+        // 결과를 DTO로 변환
+        return rawResults.stream()
+                .map(result -> new CategoryAverageUsageResponse(
+                        ((Number) result.get("categoryId")).longValue(),
+                        (String) result.get("categoryName"),
+                        result.get("averageUsageDays") != null
+                                ? ((Number) result.get("averageUsageDays")).doubleValue()
+                                : 0.0
+                ))
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/item/itemHistory/repository/ItemHistoryRepository.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/repository/ItemHistoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -23,4 +24,17 @@ public interface ItemHistoryRepository extends JpaRepository<ItemHistory, Long> 
     List<ItemHistory> findByUserIdOrderByStartDateDesc(Long userId);
 
     Optional<ItemHistory> findTopByItemIdAndEndDateIsNullOrderByStartDateDesc(Long itemId);
+
+    // 특정 사용자의 카테고리별 평균 사용 기간 조회
+    @Query("""
+            SELECT ih.item.category.id as categoryId,
+                   ih.item.category.name as categoryName,
+                   AVG(TIMESTAMPDIFF(DAY, ih.startDate, ih.endDate)) as averageUsageDays
+            FROM ItemHistory ih
+            WHERE ih.item.user.id = :userId
+              AND ih.endDate IS NOT NULL
+            GROUP BY ih.item.category.id, ih.item.category.name
+            ORDER BY ih.item.category.name
+            """)
+    List<Map<String, Object>> findAverageUsageDaysByCategoryForUser(Long userId);
 }


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #190 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 카테고리별 평균 사용 기간 통계 조회 API를 추가
  - GET /api/v1/items/statistics/category-average

- ItemHistory 데이터를 기반으로 사용자별 카테고리 평균 사용 기간(일) 을 집계하도록 구현
  - endDate IS NOT NULL 조건으로 교체 완료된 이력만 통계에 포함

- Repository 집계 결과(Map<String, Object>)를 서비스 계층에서 CategoryAverageUsageResponse로 변환하도록 구성
  - 평균 값이 null일 경우 0.0으로 안전 처리

<img width="323" height="158" alt="image" src="https://github.com/user-attachments/assets/133cb8e6-76db-4ad4-a3f0-95d87f6ff09f" />

## 💬리뷰 요청사항(선택)

- 쿼리 집계 로직이 요구사항에 맞는지
  - 교체 완료 기준을 endDate != null로 잡은 것이 적절한지
  - 평균 계산 방식이 기대와 동일한지