### PR TITLE
refactor: [BACK] 예외 처리 로직 리팩토링 및 ErrorCode 도입

### DIFF
--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -14,6 +14,7 @@ import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
 import com.back.domain.item.itemHistory.service.ItemHistoryService;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.s3.S3ImageService;
 import com.google.genai.Client;
@@ -57,25 +58,26 @@ public class ItemService {
 
     // itemId로 Item 조회 (권한 검증 없음)
     private Item findItemOrThrow(Long itemId) {
-        return itemRepository.findById(itemId).orElseThrow(() -> new ServiceException(("404-1"), "존재하지 않는 아이템입니다."));
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND));
     }
 
     // itemId + userId로 Item 조회 및 권한 검증 (쿼리 1회로 최적화)
     private Item findOwnedItemOrThrow(Long itemId, Long userId) {
         return itemRepository.findByIdAndUserId(itemId, userId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 아이템이거나 권한이 없습니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION));
     }
 
     // userId로 User 조회
     private User findUserOrThrow(Long userId) {
         return userService.findById(userId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
     }
 
     // categoryId로 Category 조회
     private Category findCategoryOrThrow(Long categoryId) {
         return categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 카테고리입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
     /**
@@ -91,7 +93,7 @@ public class ItemService {
             try {
                 return s3ImageService.upload(image);
             } catch (IOException e) {
-                throw new ServiceException("500-1", "이미지 업로드 실패: " + e.getMessage());
+                throw new ServiceException(ErrorCode.IMAGE_UPLOAD_FAILED);
             }
         }
 
@@ -138,7 +140,7 @@ public class ItemService {
     //카테고리별 목록조회용
     public List<Item> findAllByUserIdAndCategoryId(Long userId, Long categoryId) {
         if (!categoryRepository.existsById(categoryId)) {
-            throw new ServiceException("404-1", "존재하지 않는 카테고리입니다.");
+            throw new ServiceException(ErrorCode.CATEGORY_NOT_FOUND);
         }
 
         return itemRepository.findAllByUserIdAndCategoryId(userId, categoryId);
@@ -215,7 +217,7 @@ public class ItemService {
 
         // 비활성 아이템은 교체 불가
         if (!item.getIsActive()) {
-            throw new ServiceException("400-2", "비활성 상태의 아이템은 교체할 수 없습니다.");
+            throw new ServiceException(ErrorCode.INACTIVE_ITEM_CANNOT_REPLACE);
         }
 
         // 기존 진행중인 이력 endDate 넣기
@@ -305,21 +307,21 @@ public class ItemService {
                 throw se;
             }
             if (cause instanceof TimeoutException) {
-                throw new ServiceException("500", "Timeout 발생");
+                throw new ServiceException(ErrorCode.AI_TIMEOUT);
             }
-            throw new ServiceException("500", "GenAI 오류 발생");
+            throw new ServiceException(ErrorCode.AI_ERROR);
         }
     }
 
     private ItemCycleRecommendResponse parseJson(String rawText) {
         // response 자체가 null인 경우 체크
         if (rawText == null || rawText.isBlank()) {
-            throw new ServiceException("500", "AI로부터 응답을 받지 못했습니다.");
+            throw new ServiceException(ErrorCode.AI_NO_RESPONSE);
         }
 
         // Not Found 응답 처리
         if (rawText.contains("Not Found")) {
-            throw new ServiceException("404", "권장 주기를 찾을 수 없는 소모품입니다.");
+            throw new ServiceException(ErrorCode.AI_ITEM_NOT_FOUND);
         }
 
         try {
@@ -328,7 +330,7 @@ public class ItemService {
             int end = rawText.lastIndexOf("}");
 
             if (start == -1 || end == -1 || start >= end) {
-                throw new ServiceException("500", "AI 응답이 유효한 JSON 형식이 아닙니다.");
+                throw new ServiceException(ErrorCode.AI_INVALID_JSON);
             }
 
             String cleanedJson = rawText.substring(start, end + 1);
@@ -337,7 +339,7 @@ public class ItemService {
             return objectMapper.readValue(cleanedJson, ItemCycleRecommendResponse.class);
 
         } catch (Exception e) {
-            throw new ServiceException("500", "JSON 파싱 중 오류가 발생했습니다.");
+            throw new ServiceException(ErrorCode.JSON_PARSING_ERROR);
         }
     }
 

--- a/backend/src/main/java/com/back/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/back/domain/user/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.back.domain.user.user.service;
 import com.back.domain.item.item.entity.Item;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.repository.UserRepository;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.s3.S3ImageService;
 import jakarta.transaction.Transactional;
@@ -34,7 +35,7 @@ public class UserService {
         userRepository
                 .findByLoginId(loginId)
                 .ifPresent(_user -> {
-                    throw new ServiceException("409-1", "이미 존재하는 아이디입니다.");
+                    throw new ServiceException(ErrorCode.DUPLICATE_LOGIN_ID);
                 });
         password = passwordEncoder.encode(password); //패스워드 암호화 추가
 
@@ -50,7 +51,7 @@ public class UserService {
     @Transactional
     public void deleteById(Long id) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         List<String> imageUrls = user.getItems().stream()
                 .map(Item::getImgUrl)
@@ -66,7 +67,7 @@ public class UserService {
 
     public void checkPassword(User user, String password) {
         if (!passwordEncoder.matches(password, user.getPassword()))
-            throw new ServiceException("401-1", "비밀번호가 일치하지 않습니다.");
+            throw new ServiceException(ErrorCode.INVALID_PASSWORD);
     }
 
     public Optional<User> findByApiKey(String apiKey) {
@@ -89,7 +90,7 @@ public class UserService {
     @Transactional
     public User updateProfile(long id, @NotBlank @Size(min = 2, max = 30) String email) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         user.modifyUser(email, user.getPassword());
 
@@ -112,14 +113,14 @@ public class UserService {
             @NotBlank @Size(min = 2, max = 30) String currentPassword,
             @NotBlank @Size(min = 2, max = 20) String newPassword) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new ServiceException("403-1", "현재 비밀번호가 일치하지 않습니다.");
+            throw new ServiceException(ErrorCode.PASSWORD_MISMATCH);
         }
 
         if (passwordEncoder.matches(newPassword, user.getPassword())) {
-            throw new ServiceException("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+            throw new ServiceException(ErrorCode.SAME_PASSWORD);
         }
 
         String encodedPassword = passwordEncoder.encode(newPassword);

--- a/backend/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/back/global/exception/ErrorCode.java
@@ -1,0 +1,54 @@
+package com.back.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 400 Bad Request
+    INVALID_INPUT_VALUE("400-1", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_BODY("400-1", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    SAME_PASSWORD("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
+    INACTIVE_ITEM_CANNOT_REPLACE("400-2", "비활성 상태의 아이템은 교체할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    // 401 Unauthorized
+    LOGIN_REQUIRED("401-1", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_LOGIN_ID("401-1", "존재하지 않는 아이디입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_PASSWORD("401-1", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+    // 403 Forbidden
+    PASSWORD_MISMATCH("403-1", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    NO_PERMISSION("403-1", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // 404 Not Found
+    ITEM_NOT_FOUND("404-1", "존재하지 않는 아이템입니다.", HttpStatus.NOT_FOUND),
+    ITEM_NOT_FOUND_OR_NO_PERMISSION("404-1", "존재하지 않는 아이템이거나 권한이 없습니다.", HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND("404-1", "존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND),
+    CATEGORY_NOT_FOUND("404-1", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),
+    DATA_NOT_FOUND("404-1", "해당 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ONGOING_HISTORY_NOT_FOUND("404-1", "진행중인 이력이 없습니다.", HttpStatus.NOT_FOUND),
+    AI_ITEM_NOT_FOUND("404", "권장 주기를 찾을 수 없는 소모품입니다.", HttpStatus.NOT_FOUND),
+
+    // 409 Conflict
+    DUPLICATE_LOGIN_ID("409-1", "이미 존재하는 아이디입니다.", HttpStatus.CONFLICT),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR("500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_UPLOAD_FAILED("500-1", "이미지 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    EMAIL_SEND_FAILED("500-1", "메일 발송 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_TIMEOUT("500", "AI 응답 시간 초과", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_ERROR("500", "AI 처리 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_NO_RESPONSE("500", "AI로부터 응답을 받지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_INVALID_JSON("500", "AI 응답이 유효한 JSON 형식이 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    JSON_PARSING_ERROR("500", "JSON 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public String getMessageWithArgs(Object... args) {
+        return String.format(message, args);
+    }
+}

--- a/backend/src/main/java/com/back/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/back/global/exception/ServiceException.java
@@ -1,18 +1,52 @@
 package com.back.global.exception;
 
 import com.back.global.rsData.RsData;
+import lombok.Getter;
 
+@Getter
 public class ServiceException extends RuntimeException {
-    private final String resultCode;
-    private final String msg;
-    
+    private final ErrorCode errorCode;
+    private final String customMessage;
+
+    // ErrorCode만 사용하는 생성자
+    public ServiceException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.customMessage = null;
+    }
+
+    // 커스텀 메시지를 추가하는 생성자
+    public ServiceException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
+
+    // 메시지 포맷팅을 지원하는 생성자
+    public ServiceException(ErrorCode errorCode, Object... args) {
+        super(errorCode.getMessageWithArgs(args));
+        this.errorCode = errorCode;
+        this.customMessage = errorCode.getMessageWithArgs(args);
+    }
+
+    // 하위 호환성을 위한 생성자
+    @Deprecated
     public ServiceException(String resultCode, String msg) {
         super(resultCode + " : " + msg);
-        this.resultCode = resultCode;
-        this.msg = msg;
+        this.errorCode = null;
+        this.customMessage = msg;
     }
 
     public RsData<Void> getRsData() {
-        return new RsData<>(resultCode, msg, null);
+        if (errorCode != null) {
+            String message = customMessage != null ? customMessage : errorCode.getMessage();
+            return new RsData<>(errorCode.getCode(), message, null);
+        }
+        // 하위 호환성을 위한 fallback
+        return new RsData<>("500", customMessage, null);
+    }
+
+    public int getStatusCode() {
+        return errorCode != null ? errorCode.getHttpStatus().value() : 500;
     }
 }

--- a/backend/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.back.global.globalExceptionHandler;
 
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.rsData.RsData;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -19,33 +22,55 @@ import java.util.stream.Collectors;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // 공통 예외 처리
     @ExceptionHandler(ServiceException.class)
-    public RsData<Void> handle(ServiceException ex, HttpServletResponse response) {
+    public ResponseEntity<RsData<Void>> handleServiceException(
+            ServiceException ex,
+            HttpServletResponse response
+    ) {
         RsData<Void> rsData = ex.getRsData();
-        ex.getMessage();
-        response.setStatus(rsData.statusCode());
-        return rsData;
+
+        // 로깅 추가
+        if (ex.getErrorCode() != null) {
+            log.warn("ServiceException 발생: code={}, message={}",
+                    ex.getErrorCode().getCode(),
+                    rsData.msg()
+            );
+        }
+
+        // HttpServletResponse의 상태 코드 설정은 ResponseEntity가 처리하므로 제거
+        HttpStatus httpStatus = ex.getErrorCode() != null
+                ? ex.getErrorCode().getHttpStatus()
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        return new ResponseEntity<>(rsData, httpStatus);
     }
 
     // 값이 존재하지 않을 때
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<RsData<Void>> handle(NoSuchElementException ex) {
+    public ResponseEntity<RsData<Void>> handleNoSuchElementException(NoSuchElementException ex) {
+        log.warn("NoSuchElementException 발생: {}", ex.getMessage());
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "404-1",
-                        "해당 데이터가 존재하지 않습니다."
+                        ErrorCode.DATA_NOT_FOUND.getCode(),
+                        ErrorCode.DATA_NOT_FOUND.getMessage()
                 ),
-                NOT_FOUND
+                ErrorCode.DATA_NOT_FOUND.getHttpStatus()
         );
     }
 
-    // 요청값 유효성 예외처리 (@Validated 붙은 클래스)
+    // @Validated 검증 실패 처리
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<RsData<Void>> handle(ConstraintViolationException ex) {
+    public ResponseEntity<RsData<Void>> handleConstraintViolationException(
+            ConstraintViolationException ex
+    ) {
+        log.warn("ConstraintViolationException 발생: {}", ex.getMessage());
+
         String message = ex.getConstraintViolations()
                 .stream()
                 .map(violation -> {
@@ -61,15 +86,20 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
                         message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
         );
     }
 
+    // @Valid 검증 실패 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<RsData<Void>> handle(MethodArgumentNotValidException ex) {
+    public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex
+    ) {
+        log.warn("MethodArgumentNotValidException 발생");
+
         String message = ex.getBindingResult()
                 .getAllErrors()
                 .stream()
@@ -81,38 +111,62 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
                         message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
         );
     }
 
-    // Json 형식이 올바르지 않을 때
+    // JSON 형식 오류 처리
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<RsData<Void>> handle(HttpMessageNotReadableException ex) {
+    public ResponseEntity<RsData<Void>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex
+    ) {
+        log.warn("HttpMessageNotReadableException 발생: {}", ex.getMessage());
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
-                        "요청 본문이 올바르지 않습니다."
+                        ErrorCode.INVALID_REQUEST_BODY.getCode(),
+                        ErrorCode.INVALID_REQUEST_BODY.getMessage()
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_REQUEST_BODY.getHttpStatus()
         );
     }
 
-    // 요청 헤더 값이 존재하지 않을 때
+    // 요청 헤더 누락 처리
     @ExceptionHandler(MissingRequestHeaderException.class)
-    public ResponseEntity<RsData<Void>> handle(MissingRequestHeaderException ex) {
+    public ResponseEntity<RsData<Void>> handleMissingRequestHeaderException(
+            MissingRequestHeaderException ex
+    ) {
+        log.warn("MissingRequestHeaderException 발생: {}", ex.getHeaderName());
+
+        String message = "%s-%s-%s".formatted(
+                ex.getHeaderName(),
+                "NotBlank",
+                ex.getLocalizedMessage()
+        );
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
-                        "%s-%s-%s".formatted(
-                                ex.getHeaderName(),
-                                "NotBlank",
-                                ex.getLocalizedMessage()
-                        )
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
+                        message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
+        );
+    }
+
+    // 예상치 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<RsData<Void>> handleException(Exception ex) {
+        log.error("Unexpected exception 발생", ex);
+
+        return new ResponseEntity<>(
+                new RsData<>(
+                        ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                        ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
+                ),
+                ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus()
         );
     }
 }

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -1,0 +1,65 @@
+# 백엔드 예외 처리 가이드 (Exception Handling Guide)
+본 프로젝트는 예외 처리를 일관성 있게 관리하기 위해 `ErrorCode` Enum과 `ServiceException`을 사용합니다. 새로운 예외를 추가하거나 사용할 때 아래 가이드를 따라주세요.
+
+## 1. 아키텍처 개요
+- **ErrorCode**: 에러 코드(`String`), 메시지(`String`), HTTP 상태(`HttpStatus`)를 정의하는 Enum입니다. 
+- **ServiceException**: 비즈니스 로직에서 발생하는 체크 예외(Runtime)를 감싸는 커스텀 예외 클래스입니다. 
+- **GlobalExceptionHandler**: 전역에서 발생하는 예외를 잡아 표준 응답(`RsData`)으로 변환합니다.
+
+## 2. 사용 방법
+### 2.1 예외 정의하기 (`ErrorCode.java`)
+새로운 에러가 필요하면 `ErrorCode` Enum에 상수를 추가합니다. 네이밍 규칙은 `도메인_상세이유` 또는 `상황설명` (Snake Case)을 권장합니다.
+
+```Java
+public enum ErrorCode {
+// ... 기존 코드 ...
+
+    // [신규 추가] 
+    // 형식: 이름("에러코드", "메시지", HttpStatus)
+    COUPON_ALREADY_USED("409-2", "이미 사용된 쿠폰입니다.", HttpStatus.CONFLICT),
+    
+    // ...
+}
+```
+### 2.2 예외 발생시키기 (Service Layer)
+비즈니스 로직에서 예외 상황이 발생하면 `ServiceException`을 던집니다.
+
+**Case 1: 단순 에러 발생**
+
+```Java
+// 아이템을 찾을 수 없을 때
+Item item = itemRepository.findById(id)
+.orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND));
+```
+
+**Case 2: 동적 메시지 사용** 메시지에 변수(ID, 이름 등)를 포함해야 한다면 `ErrorCode` 메시지에 `%s` 포맷팅을 사용하고 인자를 전달합니다.
+
+```Java
+// ErrorCode 정의: "존재하지 않는 게시글입니다 (ID: %s)"
+throw new ServiceException(ErrorCode.POST_NOT_FOUND, postId);
+```
+
+### 2.3 하위 호환성 (주의사항)
+현재 리팩토링 과도기이므로 문자열을 직접 입력하는 생성자(`deprecated`)가 남아있으나, **신규 코드 작성 시에는 반드시 `ErrorCode`를 사용해야 합니다.**
+
+```Java
+// 지양해주세요 (Legacy)
+throw new ServiceException("500", "알 수 없는 에러");
+
+// 권장합니다
+throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+```
+
+## 3. 응답 포맷
+   클라이언트는 항상 아래와 같은 JSON 형태의 `RsData` 응답을 받게 됩니다.
+
+```JSON
+{
+"resultCode": "404-1",
+"msg": "존재하지 않는 아이템입니다.",
+"data": null
+}
+```
+
+## 4. 로깅
+   `GlobalExceptionHandler`에서 `ServiceException` 발생 시 WARN 레벨로 로그가 기록됩니다. 디버깅 시 서버 로그를 확인해 주세요.


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #207 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

## 1. 작업 내용 
- 기존에 하드코딩된 문자열("404-1", "존재하지 않는...")로 관리되던 예외 처리 로직을 ErrorCode Enum을 활용한 중앙 집중식 관리로 리팩토링
- 이를 통해 코드의 유지보수성을 높이고, 예외 응답의 일관성을 확보

## 2. 주요 변경 사항 
- ErrorCode Enum 도입: 모든 예외 코드, 메시지, HTTP 상태 코드를 한곳에서 관리하도록 변경
- ServiceException 개선: ErrorCode를 받아 처리하는 생성자를 추가하고, 동적 메시지 포맷팅 기능을 지원하도록 개선
- GlobalExceptionHandler 리팩토링:
  - HttpServletResponse 직접 제어 방식을 제거하고, Spring ResponseEntity를 사용하여 응답을 표준화
  - @Slf4j를 적용하여 예외 발생 시 로그가 남도록 개선
- Service 계층 적용: ItemService, UserService 내의 하드코딩된 예외 발생 로직을 새로운 패턴으로 전면 교체

## 3. 변경 이유
- 매직 스트링 제거: 여러 파일에 흩어진 에러 코드 문자열로 인해 오타 발생 가능성이 높고 수정이 어려움
- 가독성 향상: throw new ServiceException("404-1", ...) 대신 throw new ServiceException(ErrorCode.ITEM_NOT_FOUND)를 사용하여 코드의 의도를 명확히 함
- 로깅 강화: 예외 발생 시 로그를 남겨 디버깅 편의성을 높임

## 4. 사용 예시 
### 기존
```java
throw new ServiceException("404-1", "존재하지 않는 아이템입니다.");
```
### 변경 후
```java
// 일반적인 사용
throw new ServiceException(ErrorCode.ITEM_NOT_FOUND);

// 동적 메시지가 필요한 경우
throw new ServiceException(ErrorCode.SOME_ERROR, arg1, arg2);
```