### PR TITLE
Refactor: [BACK] ItemService 책임 분리: 통계 및 AI 추천 로직 서비스 추출

### DIFF
--- a/backend/src/main/java/com/back/domain/category/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/back/domain/category/category/controller/CategoryController.java
@@ -2,7 +2,6 @@ package com.back.domain.category.category.controller;
 
 import com.back.domain.category.category.dto.CategoryResponse;
 import com.back.domain.category.category.service.CategoryService;
-import com.back.domain.user.user.dto.UserDto;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,14 +22,17 @@ public class CategoryController {
     private final Rq rq;
 
     @GetMapping
-    @Operation(summary = "카테고리 조회")
+    @Operation(summary = "카테고리 목록 조회 (사용자별 아이템 개수 포함)")
     public RsData<List<CategoryResponse>> getCategories() {
-        UserDto actor = rq.getActor();
+        Long userId = rq.getMemberId();
+
+        // Service에서 이미 CategoryResponse DTO로 변환되어 반환됨
+        List<CategoryResponse> categories = categoryService.findAllWithItemCount(userId);
 
         return new RsData<>(
                 "200-1",
-                "카테고리 조회 성공",
-                categoryService.findAllWithItemCount(actor.id())
+                "카테고리 목록 조회 성공",
+                categories
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/category/category/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/back/domain/category/category/dto/CategoryResponse.java
@@ -1,8 +1,52 @@
 package com.back.domain.category.category.dto;
 
+import com.back.domain.category.category.entity.Category;
+
+import java.util.List;
+
 public record CategoryResponse(
         Long id,
         String name,
         Long itemCount
 ) {
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param category 변환할 Category 엔티티
+     * @return CategoryResponse DTO
+     */
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                0L  // itemCount는 별도 계산 필요
+        );
+    }
+
+    /**
+     * Entity와 itemCount로 DTO 생성
+     *
+     * @param category 변환할 Category 엔티티
+     * @param itemCount 해당 카테고리의 아이템 수
+     * @return CategoryResponse DTO
+     */
+    public static CategoryResponse of(Category category, Long itemCount) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                itemCount
+        );
+    }
+
+    /**
+     * 여러 Entity를 한번에 변환 (itemCount는 0으로 설정)
+     *
+     * @param categories 변환할 Category 엔티티 리스트
+     * @return CategoryResponse DTO 리스트
+     */
+    public static List<CategoryResponse> fromList(List<Category> categories) {
+        return categories.stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/back/domain/category/category/service/CategoryService.java
+++ b/backend/src/main/java/com/back/domain/category/category/service/CategoryService.java
@@ -13,6 +13,12 @@ import java.util.List;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
 
+    /**
+     * 특정 사용자의 카테고리별 아이템 개수와 함께 조회
+     *
+     * @param userId 사용자 ID
+     * @return 카테고리 목록 (각 카테고리별 아이템 개수 포함)
+     */
     @Transactional(readOnly = true)
     public List<CategoryResponse> findAllWithItemCount(Long userId) {
         return categoryRepository.findAllWithItemCount(userId);

--- a/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
+++ b/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
@@ -52,7 +52,7 @@ public class ItemController {
         return new RsData<>(
                 "201-1",
                 "아이템 등록 성공",
-                new ItemCreateResponse(item)
+                ItemCreateResponse.from(item)
         );
     }
 
@@ -70,14 +70,11 @@ public class ItemController {
             items = itemService.findAllByUserIdOrderByNextReplacementDateAsc(userId);
         }
 
-        List<ItemSummaryResponse> data = items.stream()
-                .map(ItemSummaryResponse::new)
-                .toList();
-
         return new RsData<>(
                 "200-1",
                 "아이템 목록 조회 성공",
-                data);
+                ItemSummaryResponse.fromList(items)
+        );
     }
 
     @GetMapping("/{itemId}")
@@ -86,9 +83,13 @@ public class ItemController {
             @PathVariable Long itemId
     ) {
         Long userId = rq.getMemberId();
-
         Item item = itemService.findByIdAndUserId(itemId, userId);
-        return new RsData<>("200-1", "아이템 단건 조회 성공", new ItemResponse(item));
+
+        return new RsData<>(
+                "200-1",
+                "아이템 단건 조회 성공",
+                ItemResponse.from(item)
+        );
     }
 
     @PutMapping("/{id}")
@@ -102,28 +103,26 @@ public class ItemController {
         // 아이템 수정
         Item item = itemService.modify(userId, id, request);
 
-        // 응답값 리턴
         return new RsData<>(
                 "200",
                 "아이템 수정 성공",
-                new ItemUpdateResponse(item)
+                ItemUpdateResponse.from(item)
         );
     }
 
     @PutMapping("/{id}/replace")
     @Operation(summary = "아이템 교체")
-    public RsData<Map<String, ItemReplaceResponse>> replaceItem(@PathVariable Long id) {
+    public RsData<ItemReplaceResponse> replaceItem(@PathVariable Long id) {
         // todo: 요청 헤더의 인증 정보를 바탕으로 user_id 받아오기
         Long userId = rq.getMemberId();
 
         // 아이템 교체
         Item item = itemService.replaceItem(userId, id);
 
-        // 응답값 리턴
         return new RsData<>(
                 "200",
                 "아이템 교체 처리 성공",
-                Map.of("item", new ItemReplaceResponse(item))
+                ItemReplaceResponse.from(item)
         );
     }
 
@@ -137,7 +136,7 @@ public class ItemController {
         return new RsData<>(
                 "200",
                 "아이템 활성화 상태 변경 성공",
-                new ItemUpdateResponse(item)
+                ItemUpdateResponse.from(item)
         );
     }
 

--- a/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
+++ b/backend/src/main/java/com/back/domain/item/item/controller/ItemController.java
@@ -2,7 +2,9 @@ package com.back.domain.item.item.controller;
 
 import com.back.domain.item.item.dto.*;
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.service.ItemRecommendationService;
 import com.back.domain.item.item.service.ItemService;
+import com.back.domain.item.item.service.ItemStatisticsService;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,20 +26,17 @@ import java.util.Map;
 public class ItemController {
     private final ItemService itemService;
     private final Rq rq;
+    private final ItemStatisticsService itemStatisticsService;
+    private final ItemRecommendationService itemRecommendationService;
 
+    // == CRUD ==
     @DeleteMapping("/{itemId}")
     @Operation(summary = "아이템 삭제")
-    public RsData<Void> deleteItem(
-            @PathVariable Long itemId
-    ) {
+    public RsData<Void> deleteItem(@PathVariable Long itemId) {
         Long userId = rq.getMemberId();
-
         itemService.deleteItem(userId, itemId);
 
-        return new RsData<>(
-                "200-1",
-                "아이템 삭제 성공"
-        );
+        return new RsData<>("200-1", "아이템 삭제 성공");
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE) //Swagger UI에 파일선택버튼 추가
@@ -46,7 +45,6 @@ public class ItemController {
             @Valid @ModelAttribute ItemCreateRequest request
     ) {
         Long userId = rq.getMemberId();
-
         Item item = itemService.createItem(userId, request);
 
         return new RsData<>(
@@ -79,9 +77,7 @@ public class ItemController {
 
     @GetMapping("/{itemId}")
     @Operation(summary = "아이템 단건 조회")
-    public RsData<ItemResponse> getItem(
-            @PathVariable Long itemId
-    ) {
+    public RsData<ItemResponse> getItem(@PathVariable Long itemId) {
         Long userId = rq.getMemberId();
         Item item = itemService.findByIdAndUserId(itemId, userId);
 
@@ -99,8 +95,6 @@ public class ItemController {
             @Valid @ModelAttribute ItemUpdateRequest request
     ) {
         Long userId = rq.getMemberId();
-
-        // 아이템 수정
         Item item = itemService.modify(userId, id, request);
 
         return new RsData<>(
@@ -115,8 +109,6 @@ public class ItemController {
     public RsData<ItemReplaceResponse> replaceItem(@PathVariable Long id) {
         // todo: 요청 헤더의 인증 정보를 바탕으로 user_id 받아오기
         Long userId = rq.getMemberId();
-
-        // 아이템 교체
         Item item = itemService.replaceItem(userId, id);
 
         return new RsData<>(
@@ -140,28 +132,15 @@ public class ItemController {
         );
     }
 
+    // == 통계 ==
+
     @GetMapping("/statistics/category-average")
     @Operation(summary = "카테고리별 평균 사용 기간 조회")
     public RsData<List<CategoryAverageUsageResponse>> getCategoryAverageUsage() {
         Long userId = rq.getMemberId();
+        List<CategoryAverageUsageResponse> data = itemStatisticsService.getCategoryAverageUsage(userId);
 
-        List<CategoryAverageUsageResponse> data = itemService.getCategoryAverageUsage(userId);
-
-        return new RsData<>(
-                "200-1",
-                "카테고리별 평균 사용 기간 조회 성공",
-                data
-        );
-    }
-
-    @GetMapping("/cycle-recommend")
-    @Operation(summary = "AI에게 아이템 주기 추천받기")
-    public RsData<ItemCycleRecommendResponse> getItemCycleRecommend(@RequestParam String name) {
-        return new RsData<>(
-                "200",
-                "추천 주기 조회 완료",
-                itemService.getItemCycleRecommend(name)
-        );
+        return new RsData<>("200-1", "카테고리별 평균 사용 기간 조회 성공", data);
     }
 
     @GetMapping("/statistics/most-replaced")
@@ -170,13 +149,21 @@ public class ItemController {
             @RequestParam(defaultValue = "10") int limit
     ) {
         Long userId = rq.getMemberId();
+        List<MostReplacedItemResponse> data = itemStatisticsService.getMostReplacedItems(userId, limit);
 
-        List<MostReplacedItemResponse> data = itemService.getMostReplacedItems(userId, limit);
+        return new RsData<>("200-1", "가장 자주 교체한 아이템 순위 조회 성공", data);
+    }
 
+    // == AI 추천 ==
+
+    @GetMapping("/cycle-recommend")
+    @Operation(summary = "AI에게 아이템 주기 추천받기")
+    public RsData<ItemCycleRecommendResponse> getItemCycleRecommend(@RequestParam String name) {
+        ItemCycleRecommendResponse recommendation = itemRecommendationService.getItemCycleRecommend(name);
         return new RsData<>(
-                "200-1",
-                "가장 자주 교체한 아이템 순위 조회 성공",
-                data
+                "200",
+                "추천 주기 조회 완료",
+                recommendation
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/CategoryAverageUsageResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/CategoryAverageUsageResponse.java
@@ -1,8 +1,38 @@
 package com.back.domain.item.item.dto;
 
+import java.util.List;
+import java.util.Map;
+
 public record CategoryAverageUsageResponse(
         Long categoryId,
         String categoryName,
         Double averageUsageDays
 ) {
+    /**
+     * Repository 쿼리 결과(Map)를 DTO로 변환
+     *
+     * @param result Repository에서 반환한 Map 데이터
+     * @return CategoryAverageUsageResponse DTO
+     */
+    public static CategoryAverageUsageResponse from(Map<String, Object> result) {
+        return new CategoryAverageUsageResponse(
+                ((Number) result.get("categoryId")).longValue(),
+                (String) result.get("categoryName"),
+                result.get("averageUsageDays") != null
+                        ? ((Number) result.get("averageUsageDays")).doubleValue()
+                        : 0.0
+        );
+    }
+
+    /**
+     * 여러 Map을 한번에 변환
+     *
+     * @param results Repository에서 반환한 Map 리스트
+     * @return CategoryAverageUsageResponse DTO 리스트
+     */
+    public static List<CategoryAverageUsageResponse> fromList(List<Map<String, Object>> results) {
+        return results.stream()
+                .map(CategoryAverageUsageResponse::from)
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemCreateResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemCreateResponse.java
@@ -1,38 +1,41 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.util.DDayCalculator;
 
 import java.time.LocalDate;
 
 public record ItemCreateResponse(
         Long id,
-
         Long userId,
-
         Long categoryId,
-
+        String categoryName,
         String name,
-
         String imgUrl,
-
         LocalDate startDate,
-
         String cycleDays,
-
         LocalDate nextReplacementDate,
-
+        Long dDay,
         Boolean isActive
 ) {
-    public ItemCreateResponse(Item item) {
-        this(
+    /**
+     * 생성된 Item Entity를 Response DTO로 변환
+     *
+     * @param item 생성된 Item 엔티티
+     * @return ItemCreateResponse DTO
+     */
+    public static ItemCreateResponse from(Item item) {
+        return new ItemCreateResponse(
                 item.getId(),
                 item.getUser().getId(),
                 item.getCategory() == null ? null : item.getCategory().getId(),
+                item.getCategory() == null ? null : item.getCategory().getName(),
                 item.getName(),
                 item.getImgUrl(),
                 item.getStartDate(),
                 item.getCycleDays(),
                 item.getNextReplacementDate(),
+                DDayCalculator.calculate(item.getNextReplacementDate()),
                 item.getIsActive()
         );
     }

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemReplaceResponse.java
@@ -1,6 +1,7 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.util.DDayCalculator;
 
 import java.time.LocalDate;
 
@@ -8,22 +9,32 @@ public record ItemReplaceResponse(
         Long id,
         Long userId,
         Long categoryId,
+        String categoryName,
         String name,
         String imgUrl,
         LocalDate startDate,
         String cycleDays,
-        LocalDate nextReplacementDate
+        LocalDate nextReplacementDate,
+        Long dDay
 ) {
-    public ItemReplaceResponse(Item item) {
-        this(
+    /**
+     * 교체된 Item Entity를 Response DTO로 변환
+     *
+     * @param item 교체된 Item 엔티티
+     * @return ItemReplaceResponse DTO
+     */
+    public static ItemReplaceResponse from(Item item) {
+        return new ItemReplaceResponse(
                 item.getId(),
                 item.getUser().getId(),
                 item.getCategory() == null ? null : item.getCategory().getId(),
+                item.getCategory() == null ? null : item.getCategory().getName(),
                 item.getName(),
                 item.getImgUrl(),
                 item.getStartDate(),
                 item.getCycleDays(),
-                item.getNextReplacementDate()
+                item.getNextReplacementDate(),
+                DDayCalculator.calculate(item.getNextReplacementDate())
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemResponse.java
@@ -1,9 +1,10 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.util.DDayCalculator;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public record ItemResponse(
         Long id,
@@ -16,10 +17,17 @@ public record ItemResponse(
         String cycleDays,
         LocalDate nextReplacementDate,
         Boolean isActive,
-        long dDay
+        Long dDay,
+        LocalDate lastReplacementDate
 ) {
-    public ItemResponse(Item item) {
-        this(
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param item 변환할 Item 엔티티
+     * @return ItemResponse DTO
+     */
+    public static ItemResponse from(Item item) {
+        return new ItemResponse(
                 item.getId(),
                 item.getUser().getId(),
                 item.getCategory() == null ? null : item.getCategory().getId(),
@@ -30,9 +38,20 @@ public record ItemResponse(
                 item.getCycleDays(),
                 item.getNextReplacementDate(),
                 item.getIsActive(),
-                item.getNextReplacementDate() == null
-                        ? 0
-                        : ChronoUnit.DAYS.between(LocalDate.now(), item.getNextReplacementDate())
+                DDayCalculator.calculate(item.getNextReplacementDate()),
+                item.getLastReplacementDate()
         );
+    }
+
+    /**
+     * 여러 Entity를 한번에 변환하는 유틸리티 메서드
+     *
+     * @param items 변환할 Item 엔티티 리스트
+     * @return ItemResponse DTO 리스트
+     */
+    public static List<ItemResponse> fromList(List<Item> items) {
+        return items.stream()
+                .map(ItemResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemSummaryResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemSummaryResponse.java
@@ -1,9 +1,10 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.util.DDayCalculator;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public record ItemSummaryResponse(
         Long id,
@@ -12,34 +13,37 @@ public record ItemSummaryResponse(
         LocalDate nextReplacementDate,
         LocalDate lastReplacementDate,
         String imgUrl,
-        long dDay,
+        Long dDay,
         Boolean isActive
 ) {
-    public ItemSummaryResponse(Item item) {
-        this(
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param item 변환할 Item 엔티티
+     * @return ItemSummaryResponse DTO
+     */
+    public static ItemSummaryResponse from(Item item) {
+        return new ItemSummaryResponse(
                 item.getId(),
                 item.getName(),
                 item.getCategory() == null ? null : item.getCategory().getName(),
                 item.getNextReplacementDate(),
                 item.getLastReplacementDate(),
                 item.getImgUrl(),
-                calculateDDay(item),
+                DDayCalculator.calculate(item.getNextReplacementDate()),
                 item.getIsActive()
         );
     }
 
     /**
-     * D-day 계산 로직
-     * - 비활성 상태: 0 반환 (프론트에서 "비활성" 표시)
-     * - 활성 상태: 실제 D-day 계산
+     * 여러 Entity를 한번에 변환하는 유틸리티 메서드
+     *
+     * @param items 변환할 Item 엔티티 리스트
+     * @return ItemSummaryResponse DTO 리스트
      */
-    private static long calculateDDay(Item item) {
-        // 다음 교체일이 없으면 -1 반환
-        if (item.getNextReplacementDate() == null) {
-            return -1;
-        }
-
-        // 항상 실제 D-day 계산
-        return ChronoUnit.DAYS.between(LocalDate.now(), item.getNextReplacementDate());
+    public static List<ItemSummaryResponse> fromList(List<Item> items) {
+        return items.stream()
+                .map(ItemSummaryResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/dto/ItemUpdateResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/ItemUpdateResponse.java
@@ -1,6 +1,7 @@
 package com.back.domain.item.item.dto;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.util.DDayCalculator;
 
 import java.time.LocalDate;
 
@@ -8,23 +9,33 @@ public record ItemUpdateResponse(
         Long id,
         Long userId,
         Long categoryId,
+        String categoryName,
         String name,
         String imgUrl,
         LocalDate startDate,
         String cycleDays,
         LocalDate nextReplacementDate,
+        Long dDay,
         Boolean isActive
 ) {
-    public ItemUpdateResponse(Item item) {
-        this(
+    /**
+     * 수정된 Item Entity를 Response DTO로 변환
+     *
+     * @param item 수정된 Item 엔티티
+     * @return ItemUpdateResponse DTO
+     */
+    public static ItemUpdateResponse from(Item item) {
+        return new ItemUpdateResponse(
                 item.getId(),
                 item.getUser().getId(),
                 item.getCategory() == null ? null : item.getCategory().getId(),
+                item.getCategory() == null ? null : item.getCategory().getName(),
                 item.getName(),
                 item.getImgUrl(),
                 item.getStartDate(),
                 item.getCycleDays(),
                 item.getNextReplacementDate(),
+                DDayCalculator.calculate(item.getNextReplacementDate()),
                 item.getIsActive()
         );
     }

--- a/backend/src/main/java/com/back/domain/item/item/dto/MostReplacedItemResponse.java
+++ b/backend/src/main/java/com/back/domain/item/item/dto/MostReplacedItemResponse.java
@@ -1,5 +1,8 @@
 package com.back.domain.item.item.dto;
 
+import java.util.List;
+import java.util.Map;
+
 public record MostReplacedItemResponse(
         Long itemId,
         String itemName,
@@ -7,4 +10,31 @@ public record MostReplacedItemResponse(
         Long replacementCount,
         String imgUrl
 ) {
+    /**
+     * Repository 쿼리 결과(Map)를 DTO로 변환
+     *
+     * @param result Repository에서 반환한 Map 데이터
+     * @return MostReplacedItemResponse DTO
+     */
+    public static MostReplacedItemResponse from(Map<String, Object> result) {
+        return new MostReplacedItemResponse(
+                ((Number) result.get("itemId")).longValue(),
+                (String) result.get("itemName"),
+                (String) result.get("categoryName"),
+                ((Number) result.get("replacementCount")).longValue(),
+                (String) result.get("imgUrl")
+        );
+    }
+
+    /**
+     * 여러 Map을 한번에 변환
+     *
+     * @param results Repository에서 반환한 Map 리스트
+     * @return MostReplacedItemResponse DTO 리스트
+     */
+    public static List<MostReplacedItemResponse> fromList(List<Map<String, Object>> results) {
+        return results.stream()
+                .map(MostReplacedItemResponse::from)
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemRecommendationService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemRecommendationService.java
@@ -1,0 +1,139 @@
+package com.back.domain.item.item.service;
+
+import com.back.domain.item.item.dto.ItemCycleRecommendResponse;
+import com.back.global.exception.ErrorCode;
+import com.back.global.exception.ServiceException;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+
+/**
+ * AI를 활용한 아이템 추천 서비스
+ * - 아이템 교체 주기 추천
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ItemRecommendationService {
+    private final Client genAiClient;
+    private final GenerateContentConfig genAiSystemConfig;
+    private final ObjectMapper objectMapper;
+
+    // AI 타임아웃 설정 (10초)
+    private static final long AI_TIMEOUT_SECONDS = 10;
+
+    // Gemini 모델명
+    private static final String GEMINI_MODEL = "gemini-2.5-flash-lite";
+
+    /**
+     * AI를 통해 아이템의 권장 교체 주기를 추천받습니다.
+     *
+     * @param itemName 아이템 이름
+     * @return 권장 교체 주기 정보
+     * @throws ServiceException AI 응답 실패, 타임아웃, JSON 파싱 실패 시
+     */
+    public ItemCycleRecommendResponse getItemCycleRecommend(String itemName) {
+        try {
+            return CompletableFuture.supplyAsync(() ->
+                            genAiClient.models.generateContent(
+                                    GEMINI_MODEL,
+                                    buildPrompt(itemName),
+                                    genAiSystemConfig)
+                    )
+                    .orTimeout(AI_TIMEOUT_SECONDS, TimeUnit.SECONDS) // 타임아웃 설정
+                    .thenApply(response -> parseJson(response.text()))
+                    .join(); // 최종 결과 대기 및 반환
+        } catch (CompletionException e) {
+            return handleCompletionException(e);
+        }
+    }
+
+    /**
+     * AI 요청을 위한 프롬프트 생성
+     */
+    private String buildPrompt(String itemName) {
+        return itemName + "의 권장 교체 주기를 알려줘.";
+    }
+
+    /**
+     * CompletionException 처리
+     */
+    private ItemCycleRecommendResponse handleCompletionException(CompletionException e) {
+        Throwable cause = e.getCause();
+
+        // parseJson에서 발생한 ServiceException인 경우 그대로 다시 던짐
+        if (cause instanceof ServiceException se) {
+            throw se;
+        }
+
+        // 타임아웃 예외 처리
+        if (cause instanceof TimeoutException) {
+            log.error("AI 응답 타임아웃: {}초 초과", AI_TIMEOUT_SECONDS);
+            throw new ServiceException(ErrorCode.AI_TIMEOUT);
+        }
+
+        // 기타 예외 처리
+        log.error("AI 처리 중 예상치 못한 오류 발생", cause);
+        throw new ServiceException(ErrorCode.AI_ERROR);
+    }
+
+    /**
+     * AI 응답 JSON 파싱
+     *
+     * @param rawText AI로부터 받은 원본 텍스트
+     * @return 파싱된 ItemCycleRecommendResponse
+     * @throws ServiceException 파싱 실패 시
+     */
+    private ItemCycleRecommendResponse parseJson(String rawText) {
+        // response 자체가 null인 경우 체크
+        if (rawText == null || rawText.isBlank()) {
+            log.error("AI로부터 빈 응답을 받음");
+            throw new ServiceException(ErrorCode.AI_NO_RESPONSE);
+        }
+
+        // Not Found 응답 처리
+        if (rawText.contains("Not Found")) {
+            log.warn("AI가 해당 아이템의 권장 주기를 찾을 수 없음: {}", rawText);
+            throw new ServiceException(ErrorCode.AI_ITEM_NOT_FOUND);
+        }
+
+        try {
+            String cleanedJson = extractJsonBlock(rawText);
+
+            // JSON을 객체로 변환
+            return objectMapper.readValue(cleanedJson, ItemCycleRecommendResponse.class);
+        } catch (Exception e) {
+            log.error("AI 응답 JSON 파싱 실패. 원본 텍스트: {}", rawText, e);
+            throw new ServiceException(ErrorCode.JSON_PARSING_ERROR);
+        }
+    }
+
+    /**
+     * 원본 텍스트에서 JSON 블록만 추출
+     *
+     * @param rawText 원본 텍스트
+     * @return 추출된 JSON 문자열
+     * @throws ServiceException JSON 블록을 찾을 수 없을 때
+     */
+    private String extractJsonBlock(String rawText) {
+        // {} 블록만 추출
+        int start = rawText.indexOf("{");
+        int end = rawText.lastIndexOf("}");
+
+        if (start == -1 || end == -1 || start >= end) {
+            log.error("AI 응답에서 유효한 JSON 블록을 찾을 수 없음: {}", rawText);
+            throw new ServiceException(ErrorCode.AI_INVALID_JSON);
+        }
+
+        return rawText.substring(start, end + 1);
+    }
+}

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -14,6 +14,7 @@ import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
 import com.back.domain.item.itemHistory.service.ItemHistoryService;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.s3.S3ImageService;
 import com.google.genai.Client;
@@ -57,25 +58,26 @@ public class ItemService {
 
     // itemId로 Item 조회 (권한 검증 없음)
     private Item findItemOrThrow(Long itemId) {
-        return itemRepository.findById(itemId).orElseThrow(() -> new ServiceException(("404-1"), "존재하지 않는 아이템입니다."));
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND));
     }
 
     // itemId + userId로 Item 조회 및 권한 검증 (쿼리 1회로 최적화)
     private Item findOwnedItemOrThrow(Long itemId, Long userId) {
         return itemRepository.findByIdAndUserId(itemId, userId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 아이템이거나 권한이 없습니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION));
     }
 
     // userId로 User 조회
     private User findUserOrThrow(Long userId) {
         return userService.findById(userId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
     }
 
     // categoryId로 Category 조회
     private Category findCategoryOrThrow(Long categoryId) {
         return categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 카테고리입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
     /**
@@ -91,7 +93,7 @@ public class ItemService {
             try {
                 return s3ImageService.upload(image);
             } catch (IOException e) {
-                throw new ServiceException("500-1", "이미지 업로드 실패: " + e.getMessage());
+                throw new ServiceException(ErrorCode.IMAGE_UPLOAD_FAILED);
             }
         }
 
@@ -138,7 +140,7 @@ public class ItemService {
     //카테고리별 목록조회용
     public List<Item> findAllByUserIdAndCategoryId(Long userId, Long categoryId) {
         if (!categoryRepository.existsById(categoryId)) {
-            throw new ServiceException("404-1", "존재하지 않는 카테고리입니다.");
+            throw new ServiceException(ErrorCode.CATEGORY_NOT_FOUND);
         }
 
         return itemRepository.findAllByUserIdAndCategoryId(userId, categoryId);
@@ -215,7 +217,7 @@ public class ItemService {
 
         // 비활성 아이템은 교체 불가
         if (!item.getIsActive()) {
-            throw new ServiceException("400-2", "비활성 상태의 아이템은 교체할 수 없습니다.");
+            throw new ServiceException(ErrorCode.INACTIVE_ITEM_CANNOT_REPLACE);
         }
 
         // 기존 진행중인 이력 endDate 넣기
@@ -305,21 +307,21 @@ public class ItemService {
                 throw se;
             }
             if (cause instanceof TimeoutException) {
-                throw new ServiceException("500", "Timeout 발생");
+                throw new ServiceException(ErrorCode.AI_TIMEOUT);
             }
-            throw new ServiceException("500", "GenAI 오류 발생");
+            throw new ServiceException(ErrorCode.AI_ERROR);
         }
     }
 
     private ItemCycleRecommendResponse parseJson(String rawText) {
         // response 자체가 null인 경우 체크
         if (rawText == null || rawText.isBlank()) {
-            throw new ServiceException("500", "AI로부터 응답을 받지 못했습니다.");
+            throw new ServiceException(ErrorCode.AI_NO_RESPONSE);
         }
 
         // Not Found 응답 처리
         if (rawText.contains("Not Found")) {
-            throw new ServiceException("404", "권장 주기를 찾을 수 없는 소모품입니다.");
+            throw new ServiceException(ErrorCode.AI_ITEM_NOT_FOUND);
         }
 
         try {
@@ -328,7 +330,7 @@ public class ItemService {
             int end = rawText.lastIndexOf("}");
 
             if (start == -1 || end == -1 || start >= end) {
-                throw new ServiceException("500", "AI 응답이 유효한 JSON 형식이 아닙니다.");
+                throw new ServiceException(ErrorCode.AI_INVALID_JSON);
             }
 
             String cleanedJson = rawText.substring(start, end + 1);
@@ -337,7 +339,7 @@ public class ItemService {
             return objectMapper.readValue(cleanedJson, ItemCycleRecommendResponse.class);
 
         } catch (Exception e) {
-            throw new ServiceException("500", "JSON 파싱 중 오류가 발생했습니다.");
+            throw new ServiceException(ErrorCode.JSON_PARSING_ERROR);
         }
     }
 

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -39,6 +39,11 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * 아이템의 기본 CRUD 작업을 담당하는 서비스
+ * - 생성, 조회, 수정, 삭제
+ * - 교체, 활성화 토글
+ */
 @Service
 @RequiredArgsConstructor
 public class ItemService {
@@ -49,8 +54,9 @@ public class ItemService {
     private final S3ImageService s3ImageService;
     private final ItemHistoryRepository itemHistoryRepository;
     private final Client genAiClient;
-    private final GenerateContentConfig genAiSystemConfig;
     private final ObjectMapper objectMapper;
+
+    // == 조회 ==
 
     public Optional<Item> findById(Long id) {
         return itemRepository.findById(id);
@@ -80,51 +86,6 @@ public class ItemService {
                 .orElseThrow(() -> new ServiceException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
-    /**
-     * 이미지 URL 결정 로직 (중복 제거)
-     * image 업로드된 파일
-     * providedUrl 프론트에서 전달한 URL
-     * existingUrl 기존 이미지 URL (수정 시)
-     * return 최종 이미지 URL
-     */
-    private String resolveImageUrl(MultipartFile image, String providedUrl, String existingUrl) {
-        // 파일이 있으면 S3 업로드
-        if (image != null && !image.isEmpty()) {
-            try {
-                return s3ImageService.upload(image);
-            } catch (IOException e) {
-                throw new ServiceException(ErrorCode.IMAGE_UPLOAD_FAILED);
-            }
-        }
-
-        // 프론트에서 보낸 URL
-        if (StringUtils.isNotBlank(providedUrl)) {
-            return providedUrl;
-        }
-
-        // 기존 URL 유지 (수정 시), 없으면 빈 문자열
-        return StringUtils.isNotBlank(existingUrl) ? existingUrl : "";
-    }
-
-    // itemId로 아이템을 조회하고 요청자(userId)가 소유자인지 검증한 뒤 실제 삭제 수행
-    @Transactional
-    public void deleteItem(Long userId, Long itemId) {
-        Item item = findOwnedItemOrThrow(itemId, userId);// 쿼리 1회로 감소
-        String imageUrl = item.getImgUrl();
-
-        itemRepository.delete(item);
-
-        //  현재 진행 중인 트랜잭션이 성공적으로 커밋되었을 때만 S3 삭제 실행
-        if (imageUrl != null && !imageUrl.isEmpty()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    s3ImageService.delete(imageUrl);
-                }
-            });
-        }
-    }
-
     //목록조회용
     @Transactional(readOnly = true)
     public List<Item> findAllByUserIdOrderByNextReplacementDateAsc(Long userId) {
@@ -136,6 +97,7 @@ public class ItemService {
     public Item findByIdAndUserId(Long itemId, Long userId) {
         return findOwnedItemOrThrow(itemId, userId); // 메서드 재사용
     }
+
 
     //카테고리별 목록조회용
     public List<Item> findAllByUserIdAndCategoryId(Long userId, Long categoryId) {
@@ -151,7 +113,9 @@ public class ItemService {
         return itemRepository.count();
     }
 
+    // == 생성 ==
 
+    // 아이템 생성 (내부용)
     @Transactional
     public Item create(
             Long userId,
@@ -172,16 +136,17 @@ public class ItemService {
         return itemRepository.save(item);
     }
 
+    // 아이템 생성 (외부용)
     @Transactional
     public Item createItem(Long userId, ItemCreateRequest request) {
-        Category category = findCategoryOrThrow(request.categoryId()); // 메서드 재사용 + 올바른 에러 메시지
+        Category category = findCategoryOrThrow(request.categoryId());
 
         LocalDate startDate = request.resolvedStartDate();
         CyclePeriod cyclePeriod = CyclePeriod.from(request.cycleDays());
         LocalDate nextReplacementDate = cyclePeriod.addTo(startDate);
 
 
-        String finalImgUrl = resolveImageUrl(request.image(), request.imgUrl(), null); // 중복 제거
+        String finalImgUrl = resolveImageUrl(request.image(), request.imgUrl(), null);
 
         Item item = create(
                 userId,
@@ -200,6 +165,35 @@ public class ItemService {
         return item;
     }
 
+    // == 수정 ==
+
+    // 아이템 수정
+    @Transactional
+    public Item modify(Long userId, Long itemId, ItemUpdateRequest request) {
+        Item item = findOwnedItemOrThrow(itemId, userId); // 쿼리 1회로 감소
+        Category category = findCategoryOrThrow(request.categoryId()); // 메서드 재사용
+
+        String finalImgUrl = resolveImageUrl(request.image(), request.imgUrl(), item.getImgUrl()); // 중복 제거
+
+        // // 기존 이미지 파일이 동일하지 않으면 삭제
+        if (!Objects.equals(finalImgUrl, item.getImgUrl())) {
+            s3ImageService.delete(item.getImgUrl());
+        }
+
+        // 주기(cycleDays) 수정 시 다음 교체일도 함께 변경
+        LocalDate nextReplacementDate = item.getNextReplacementDate();
+        if (!Objects.equals(request.cycleDays(), item.getCycleDays())) {
+            CyclePeriod cyclePeriod = CyclePeriod.from(request.cycleDays());
+            nextReplacementDate = cyclePeriod.addTo(item.getStartDate());
+        }
+
+        item.modify(category, request.name(), finalImgUrl, request.cycleDays(), nextReplacementDate,
+                request.isActive());
+
+        return item;
+    }
+
+    // 아이템 날짜 수정 (교체 시 사용)
     public void modifyDate(Item item) {
         // 시작일 변경 : 교체를 요청한 시각
         LocalDate newStartDate = LocalDate.now();
@@ -211,6 +205,7 @@ public class ItemService {
         item.modifyDate(newStartDate, newNextReplacementDate);
     }
 
+    // 아이템 교체
     @Transactional
     public Item replaceItem(Long userId, Long itemId) {
         Item item = findOwnedItemOrThrow(itemId, userId); // 쿼리 1회로 감소
@@ -234,117 +229,58 @@ public class ItemService {
     }
 
     @Transactional
-    public Item modify(Long userId, Long itemId, ItemUpdateRequest request) {
-        Item item = findOwnedItemOrThrow(itemId, userId); // 쿼리 1회로 감소
-        Category category = findCategoryOrThrow(request.categoryId()); // 메서드 재사용
-
-        String finalImgUrl = resolveImageUrl(request.image(), request.imgUrl(), item.getImgUrl()); // 중복 제거
-
-        if (!Objects.equals(finalImgUrl, item.getImgUrl())) { //기존 이미지 파일이 동일하지 않으면
-            s3ImageService.delete(item.getImgUrl()); //기존 이미지 삭제
-        }
-
-        // 주기(cycleDays) 수정 시 다음 교체일도 함께 변경
-        LocalDate nextReplacementDate = item.getNextReplacementDate();
-        if (!Objects.equals(request.cycleDays(), item.getCycleDays())) {
-            CyclePeriod cyclePeriod = CyclePeriod.from(request.cycleDays());
-            nextReplacementDate = cyclePeriod.addTo(item.getStartDate());
-        }
-
-        // 아이템 수정
-        item.modify(category, request.name(), finalImgUrl, request.cycleDays(), nextReplacementDate,
-                request.isActive());
-
-        return item;
-    }
-
-    @Transactional
     public Item toggleActive(Long userId, Long itemId) {
-        Item item = findOwnedItemOrThrow(itemId, userId); // 쿼리 1회로 감소
-
-        // 활성화 상태 토글
+        Item item = findOwnedItemOrThrow(itemId, userId);
         item.toggleActive();
-
         return item;
     }
 
+    // == 삭제 ==
+
+    // 아이템 삭제
+    // itemId로 아이템을 조회하고 요청자(userId)가 소유자인지 검증한 뒤 실제 삭제 수행
+    @Transactional
+    public void deleteItem(Long userId, Long itemId) {
+        Item item = findOwnedItemOrThrow(itemId, userId);
+        String imageUrl = item.getImgUrl();
+
+        itemRepository.delete(item);
+
+        // 트랜잭션 커밋 후 S3 삭제 실행
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    s3ImageService.delete(imageUrl);
+                }
+            });
+        }
+    }
+
+    // == 유틸 메서드 ==
     /**
-     * 특정 사용자의 카테고리별 평균 사용 기간 조회
+     * 이미지 URL 결정 로직
+     * image 업로드된 파일
+     * providedUrl 프론트에서 전달한 URL
+     * existingUrl 기존 이미지 URL (수정 시)
+     * return 최종 이미지 URL
      */
-    @Transactional(readOnly = true)
-    public List<CategoryAverageUsageResponse> getCategoryAverageUsage(Long userId) {
-        // Repository에서 카테고리별 평균 사용 기간을 조회
-        List<Map<String, Object>> rawResults = itemHistoryRepository
-                .findAverageUsageDaysByCategoryForUser(userId);
-
-        // 결과를 DTO로 변환
-        return CategoryAverageUsageResponse.fromList(rawResults);
-    }
-
-    public ItemCycleRecommendResponse getItemCycleRecommend(String name) {
-        try {
-            return CompletableFuture.supplyAsync(() ->
-                            genAiClient.models.generateContent(
-                                    "gemini-2.5-flash-lite",
-                                    name + "의 권장 교체 주기를 알려줘.",
-                                    genAiSystemConfig)
-                    )
-                    .orTimeout(10, TimeUnit.SECONDS) // 타임아웃 설정
-                    .thenApply(response -> parseJson(response.text()))
-                    .join(); // 최종 결과 대기 및 반환
-        } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            // parseJson에서 발생한 ServiceException인 경우 그대로 다시 던짐
-            if (cause instanceof ServiceException se) {
-                throw se;
+    private String resolveImageUrl(MultipartFile image, String providedUrl, String existingUrl) {
+        // 파일이 있으면 S3 업로드
+        if (image != null && !image.isEmpty()) {
+            try {
+                return s3ImageService.upload(image);
+            } catch (IOException e) {
+                throw new ServiceException(ErrorCode.IMAGE_UPLOAD_FAILED);
             }
-            if (cause instanceof TimeoutException) {
-                throw new ServiceException(ErrorCode.AI_TIMEOUT);
-            }
-            throw new ServiceException(ErrorCode.AI_ERROR);
-        }
-    }
-
-    private ItemCycleRecommendResponse parseJson(String rawText) {
-        // response 자체가 null인 경우 체크
-        if (rawText == null || rawText.isBlank()) {
-            throw new ServiceException(ErrorCode.AI_NO_RESPONSE);
         }
 
-        // Not Found 응답 처리
-        if (rawText.contains("Not Found")) {
-            throw new ServiceException(ErrorCode.AI_ITEM_NOT_FOUND);
+        // 프론트에서 보낸 URL
+        if (StringUtils.isNotBlank(providedUrl)) {
+            return providedUrl;
         }
 
-        try {
-            // {} 블록만 추출
-            int start = rawText.indexOf("{");
-            int end = rawText.lastIndexOf("}");
-
-            if (start == -1 || end == -1 || start >= end) {
-                throw new ServiceException(ErrorCode.AI_INVALID_JSON);
-            }
-
-            String cleanedJson = rawText.substring(start, end + 1);
-
-            // JSON을 객체로 변환
-            return objectMapper.readValue(cleanedJson, ItemCycleRecommendResponse.class);
-
-        } catch (Exception e) {
-            throw new ServiceException(ErrorCode.JSON_PARSING_ERROR);
-        }
-    }
-
-    /**
-     * 특정 사용자의 가장 자주 교체한 아이템 순위 조회
-     */
-    @Transactional(readOnly = true)
-    public List<MostReplacedItemResponse> getMostReplacedItems(Long userId, int limit) {
-        // Repository에서 가장 자주 교체한 아이템 순위를 조회
-        List<Map<String, Object>> rawResults = itemHistoryRepository
-                .findMostReplacedItemsByUser(userId, limit);
-
-        // 결과를 DTO로 변환
-        return MostReplacedItemResponse.fromList(rawResults);
+        // 기존 URL 유지 (수정 시), 없으면 빈 문자열
+        return StringUtils.isNotBlank(existingUrl) ? existingUrl : "";
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemService.java
@@ -278,15 +278,7 @@ public class ItemService {
                 .findAverageUsageDaysByCategoryForUser(userId);
 
         // 결과를 DTO로 변환
-        return rawResults.stream()
-                .map(result -> new CategoryAverageUsageResponse(
-                        ((Number) result.get("categoryId")).longValue(),
-                        (String) result.get("categoryName"),
-                        result.get("averageUsageDays") != null
-                                ? ((Number) result.get("averageUsageDays")).doubleValue()
-                                : 0.0
-                ))
-                .toList();
+        return CategoryAverageUsageResponse.fromList(rawResults);
     }
 
     public ItemCycleRecommendResponse getItemCycleRecommend(String name) {
@@ -353,14 +345,6 @@ public class ItemService {
                 .findMostReplacedItemsByUser(userId, limit);
 
         // 결과를 DTO로 변환
-        return rawResults.stream()
-                .map(result -> new MostReplacedItemResponse(
-                        ((Number) result.get("itemId")).longValue(),
-                        (String) result.get("itemName"),
-                        (String) result.get("categoryName"),
-                        ((Number) result.get("replacementCount")).longValue(),
-                        (String) result.get("imgUrl")
-                ))
-                .toList();
+        return MostReplacedItemResponse.fromList(rawResults);
     }
 }

--- a/backend/src/main/java/com/back/domain/item/item/service/ItemStatisticsService.java
+++ b/backend/src/main/java/com/back/domain/item/item/service/ItemStatisticsService.java
@@ -1,0 +1,53 @@
+package com.back.domain.item.item.service;
+
+import com.back.domain.item.item.dto.CategoryAverageUsageResponse;
+import com.back.domain.item.item.dto.MostReplacedItemResponse;
+import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 아이템 통계 정보를 제공하는 서비스
+ * - 카테고리별 평균 사용 기간
+ * - 가장 자주 교체한 아이템 순위
+ */
+@Service
+@RequiredArgsConstructor
+public class ItemStatisticsService {
+    private final ItemHistoryRepository itemHistoryRepository;
+
+    /**
+     * 특정 사용자의 카테고리별 평균 사용 기간 조회
+     *
+     * @param userId 사용자 ID
+     * @return 카테고리별 평균 사용 기간 목록
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryAverageUsageResponse> getCategoryAverageUsage(Long userId) {
+        // Repository에서 카테고리별 평균 사용 기간을 조회
+        List<Map<String, Object>> rawResults = itemHistoryRepository
+                .findAverageUsageDaysByCategoryForUser(userId);
+
+        // 결과를 DTO로 변환
+        return CategoryAverageUsageResponse.fromList(rawResults);
+    }
+
+    /**
+     * 특정 사용자의 가장 자주 교체한 아이템 순위 조회
+     *
+     * @param userId 사용자 ID
+     * @param limit 조회할 최대 개수
+     * @return 가장 자주 교체한 아이템 목록
+     */
+    @Transactional(readOnly = true)
+    public List<MostReplacedItemResponse> getMostReplacedItems(Long userId, int limit) {
+        List<Map<String, Object>> rawResults = itemHistoryRepository
+                .findMostReplacedItemsByUser(userId, limit);
+
+        return MostReplacedItemResponse.fromList(rawResults);
+    }
+}

--- a/backend/src/main/java/com/back/domain/item/item/util/DDayCalculator.java
+++ b/backend/src/main/java/com/back/domain/item/item/util/DDayCalculator.java
@@ -1,0 +1,32 @@
+package com.back.domain.item.item.util;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * D-day 계산을 위한 유틸리티 클래스
+ * 아이템의 다음 교체일까지 남은 일수를 계산합니다.
+ */
+public class DDayCalculator {
+
+    private DDayCalculator() {
+        // 유틸리티 클래스이므로 인스턴스화 방지
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    /**
+     * D-day 계산 로직
+     * - 다음 교체일이 없으면 -1 반환
+     * - 있으면 오늘부터 다음 교체일까지 남은 일수 계산
+     * - 음수가 나올 수 있음 (교체일이 지난 경우)
+     *
+     * @param nextReplacementDate 다음 교체 예정일
+     * @return D-day (남은 일수, null인 경우 -1)
+     */
+    public static Long calculate(LocalDate nextReplacementDate) {
+        if (nextReplacementDate == null) {
+            return -1L;
+        }
+        return ChronoUnit.DAYS.between(LocalDate.now(), nextReplacementDate);
+    }
+}

--- a/backend/src/main/java/com/back/domain/item/itemHistory/controller/ItemHistoryController.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/controller/ItemHistoryController.java
@@ -28,18 +28,19 @@ public class ItemHistoryController {
     @Operation(summary = "전체 아이템 이력 조회", description = "전체 아이템의 이력을 일괄 조회합니다.")
     public RsData<List<ItemAllHistoryResponse>> getAllItemHistories() {
         Long userId = rq.getMemberId();
-        List<ItemAllHistoryResponse> list = itemHistoryService.getAllItemHistories(userId);
 
-        return new RsData<>(
-                "200",
-                "전체 아이템 이력 조회 성공",
-                list
-        );
+        // Service에서 이미 변환된 DTO 리스트를 반환
+        List<ItemAllHistoryResponse> histories = itemHistoryService.getAllItemHistories(userId);
+
+        return new RsData<>("200-1", "전체 아이템 이력 조회 성공", histories);
     }
 
     @GetMapping("/{itemId}/histories")
-    @Operation(summary = "아이템 이력 조회", description = "특정 아이템의 이력을 조회합니다.")
-    public List<ItemHistoryResponse> getItemHistories(@PathVariable Long itemId) {
-        return itemHistoryService.getItemHistories(itemId);
+    @Operation(summary = "특정 아이템의 교체 이력 조회", description = "특정 아이템의 이력을 조회합니다.")
+    public RsData<List<ItemHistoryResponse>> getItemHistories(@PathVariable Long itemId) {
+        // Service에서 이미 변환된 DTO 리스트를 반환
+        List<ItemHistoryResponse> histories = itemHistoryService.getItemHistories(itemId);
+
+        return new RsData<>("200-1", "아이템 이력 조회 성공", histories);
     }
 }

--- a/backend/src/main/java/com/back/domain/item/itemHistory/dto/ItemAllHistoryResponse.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/dto/ItemAllHistoryResponse.java
@@ -3,23 +3,44 @@ package com.back.domain.item.itemHistory.dto;
 import com.back.domain.item.itemHistory.entity.ItemHistory;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record ItemAllHistoryResponse(
         Long id,
         Long itemId,
         String itemName,
         String categoryName,
+        String imgUrl,
         LocalDate startDate,
-        Long usedDays
+        LocalDate endDate
 ) {
-    public static ItemAllHistoryResponse from(ItemHistory history) {
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param itemHistory 변환할 ItemHistory 엔티티
+     * @return ItemAllHistoryResponse DTO
+     */
+    public static ItemAllHistoryResponse from(ItemHistory itemHistory) {
         return new ItemAllHistoryResponse(
-                history.getId(),
-                history.getItem().getId(),
-                history.getItem().getName(),
-                history.getItem().getCategory().getName(),
-                history.getStartDate(),
-                history.getUsedDays()
+                itemHistory.getId(),
+                itemHistory.getItem().getId(),
+                itemHistory.getItem().getName(),
+                itemHistory.getItem().getCategory() == null ? null : itemHistory.getItem().getCategory().getName(),
+                itemHistory.getItem().getImgUrl(),
+                itemHistory.getStartDate(),
+                itemHistory.getEndDate()
         );
+    }
+
+    /**
+     * 여러 Entity를 한번에 변환
+     *
+     * @param itemHistories 변환할 ItemHistory 엔티티 리스트
+     * @return ItemAllHistoryResponse DTO 리스트
+     */
+    public static List<ItemAllHistoryResponse> fromList(List<ItemHistory> itemHistories) {
+        return itemHistories.stream()
+                .map(ItemAllHistoryResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/item/itemHistory/dto/ItemHistoryResponse.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/dto/ItemHistoryResponse.java
@@ -3,18 +3,38 @@ package com.back.domain.item.itemHistory.dto;
 import com.back.domain.item.itemHistory.entity.ItemHistory;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public record ItemHistoryResponse(
         Long id,
+        Long itemId,
         LocalDate startDate,
-        Long usedDays
+        LocalDate endDate
 ) {
-    public static ItemHistoryResponse from(ItemHistory history) {
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param itemHistory 변환할 ItemHistory 엔티티
+     * @return ItemHistoryResponse DTO
+     */
+    public static ItemHistoryResponse from(ItemHistory itemHistory) {
         return new ItemHistoryResponse(
-                history.getId(),
-                history.getStartDate(),
-                history.getUsedDays()
+                itemHistory.getId(),
+                itemHistory.getItem().getId(),
+                itemHistory.getStartDate(),
+                itemHistory.getEndDate()
         );
+    }
+
+    /**
+     * 여러 Entity를 한번에 변환
+     *
+     * @param itemHistories 변환할 ItemHistory 엔티티 리스트
+     * @return ItemHistoryResponse DTO 리스트
+     */
+    public static List<ItemHistoryResponse> fromList(List<ItemHistory> itemHistories) {
+        return itemHistories.stream()
+                .map(ItemHistoryResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.java
@@ -5,6 +5,7 @@ import com.back.domain.item.itemHistory.dto.ItemAllHistoryResponse;
 import com.back.domain.item.itemHistory.dto.ItemHistoryResponse;
 import com.back.domain.item.itemHistory.entity.ItemHistory;
 import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,23 +27,20 @@ public class ItemHistoryService {
 
     @Transactional(readOnly = true)
     public List<ItemHistoryResponse> getItemHistories(Long itemId) {
-        return itemHistoryRepository.findByItemIdOrderByStartDateDesc(itemId).stream()
-                .map(ItemHistoryResponse::from)
-                .toList();
+        List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(itemId);
+        return ItemHistoryResponse.fromList(histories);
     }
 
     @Transactional(readOnly = true)
     public List<ItemAllHistoryResponse> getAllItemHistories(Long userId) {
-        return itemHistoryRepository.findByUserIdOrderByStartDateDesc(userId)
-                .stream()
-                .map(ItemAllHistoryResponse::from)
-                .toList();
+        List<ItemHistory> histories = itemHistoryRepository.findByUserIdOrderByStartDateDesc(userId);
+        return ItemAllHistoryResponse.fromList(histories);
     }
 
     @Transactional
     public void endHistory(Long itemId, LocalDate endDate) {
         ItemHistory ongoing = itemHistoryRepository.findTopByItemIdAndEndDateIsNullOrderByStartDateDesc(itemId)
-                .orElseThrow(() -> new ServiceException("404-1", "진행중인 이력이 없습니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.ONGOING_HISTORY_NOT_FOUND));
 
         ongoing.end(endDate);
     }

--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.java
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.java
@@ -3,6 +3,7 @@ package com.back.domain.user.user.controller;
 import com.back.domain.user.user.dto.*;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
@@ -51,7 +52,7 @@ public class ApiV1UserController {
         return new RsData<>(
                 "201-1",
                 "%s님 환영합니다. 회원가입이 완료되었습니다.".formatted(user.getLoginId()),
-                new UserDto(user)
+                UserDto.from(user)
         );
     }
 
@@ -62,7 +63,7 @@ public class ApiV1UserController {
             @Valid @RequestBody UserLoginRequest reqBody
     ) {
         User user = userService.findByLoginId(reqBody.loginId())
-                .orElseThrow(() -> new ServiceException("401-1", "존재하지 않는 아이디입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.INVALID_LOGIN_ID));
 
         userService.checkPassword(
                 user,
@@ -77,21 +78,17 @@ public class ApiV1UserController {
         return new RsData<>(
                 "200-1",
                 "%s님 환영합니다.".formatted(user.getLoginId()),
-                new UserLoginResponse(
-                        new UserDto(user),
-                        user.getApiKey(),
-                        accessToken
-                )
+                UserLoginResponse.of(user, user.getApiKey(), accessToken)
         );
     }
 
     @DeleteMapping("/me")
     @Operation(summary = "탈퇴")
-    public RsData<Void> deleteMe() {
+    public RsData<UserDto> deleteMe() {
         UserDto actor = rq.getActor();
 
         if (actor == null) {
-            throw new ServiceException("401-1", "로그인이 필요합니다.");
+            throw new ServiceException(ErrorCode.LOGIN_REQUIRED);
         }
 
         userService.deleteById(actor.id());
@@ -100,8 +97,9 @@ public class ApiV1UserController {
 
         return new RsData<>(
                 "200-1",
-                "회원탈퇴가 완료되었습니다.",
-                null);
+                "%s님의 정보입니다.".formatted(actor.loginId()),
+                actor
+        );
     }
 
     @GetMapping("/me")
@@ -113,7 +111,7 @@ public class ApiV1UserController {
         UserDto actor = rq.getActor();
 
         if (actor == null) {
-            throw new ServiceException("401-1", "로그인이 필요합니다.");
+            throw new ServiceException(ErrorCode.LOGIN_REQUIRED);
         }
 
         // UserDto는 이미 필요한 정보를 포함하고 있으므로 그대로 반환
@@ -145,7 +143,7 @@ public class ApiV1UserController {
     ) {
         UserDto actor = rq.getActor();
         if (actor == null) {
-            throw new ServiceException("401-1", "로그인이 필요합니다.");
+            throw new ServiceException(ErrorCode.LOGIN_REQUIRED);
         }
 
         User updatedUser = userService.updateProfile(actor.id(), request.email());
@@ -158,7 +156,7 @@ public class ApiV1UserController {
         return new RsData<>(
                 "200-2",
                 "회원정보가 수정되었습니다.",
-                new UserUpdateResponse(updatedUser)
+                UserUpdateResponse.from(updatedUser)
         );
     }
 
@@ -169,7 +167,7 @@ public class ApiV1UserController {
     ) {
         UserDto actor = rq.getActor();
         if (actor == null) {
-            throw new ServiceException("401-1", "로그인이 필요합니다.");
+            throw new ServiceException(ErrorCode.LOGIN_REQUIRED);
         }
 
         User updatedUser = userService.changePassword(
@@ -186,7 +184,7 @@ public class ApiV1UserController {
         return new RsData<>(
                 "200-2",
                 "비밀번호가 변경되었습니다.",
-                new UserUpdateResponse(updatedUser)
+                UserUpdateResponse.from(updatedUser)
         );
     }
 
@@ -197,11 +195,11 @@ public class ApiV1UserController {
     ) {
         UserDto actor = rq.getActor();
         if (actor == null) {
-            throw new ServiceException("401-1", "로그인이 필요합니다.");
+            throw new ServiceException(ErrorCode.LOGIN_REQUIRED);
         }
 
         User user = userService.findById(actor.id())
-                .orElseThrow(() -> new ServiceException("404-1", "사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         userService.checkPassword(user, request.password());
 

--- a/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.java
+++ b/backend/src/main/java/com/back/domain/user/user/controller/ApiV1UserController.java
@@ -26,21 +26,9 @@ public class ApiV1UserController {
     @PostMapping("/signup")
     @Transactional
     @Operation(summary = "회원가입")
-    public RsData<UserDto> join(
-            @Valid @RequestBody UserJoinRequest request,
-            BindingResult bindingResult // [중요] 위치는 반드시 검증 객체 바로 뒤!
-    ) {
-        // 유효성 검사 실패 체크
-        if (bindingResult.hasErrors()) {
-            String errorMessage = bindingResult.getFieldError().getDefaultMessage();
-
-            // 실패 응답 리턴
-            return new RsData<>(
-                    "400",
-                    errorMessage, //
-                    null
-            );
-        }
+    public RsData<UserDto> join(@Valid @RequestBody UserJoinRequest request) {
+        // BindingResult 제거 - GlobalExceptionHandler가 자동으로 처리
+        // 유효성 검증 실패 시 MethodArgumentNotValidException 발생 → 핸들러가 처리
 
         // 성공 시 로직 실행
         User user = userService.join(
@@ -92,7 +80,6 @@ public class ApiV1UserController {
         }
 
         userService.deleteById(actor.id());
-
         rq.setCookie("accessToken", "");
 
         return new RsData<>(

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserDto.java
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserDto.java
@@ -2,22 +2,36 @@ package com.back.domain.user.user.dto;
 
 import com.back.domain.user.user.entity.User;
 
+import java.util.List;
+
 public record UserDto(
-        long id,
+        Long id,
         String loginId,
         String email
 ) {
-    public UserDto(long id, String loginId, String email) {
-        this.id = id;
-        this.loginId = loginId;
-        this.email = email;
-    }
-
-    public UserDto(User user) {
-        this(
+    /**
+     * Entity -> DTO 변환을 위한 정적 팩토리 메서드
+     *
+     * @param user 변환할 User 엔티티
+     * @return UserDto
+     */
+    public static UserDto from(User user) {
+        return new UserDto(
                 user.getId(),
                 user.getLoginId(),
                 user.getEmail()
         );
+    }
+
+    /**
+     * 여러 Entity를 한번에 변환
+     *
+     * @param users 변환할 User 엔티티 리스트
+     * @return UserDto 리스트
+     */
+    public static List<UserDto> fromList(List<User> users) {
+        return users.stream()
+                .map(UserDto::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserLoginResponse.java
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserLoginResponse.java
@@ -1,8 +1,25 @@
 package com.back.domain.user.user.dto;
 
+import com.back.domain.user.user.entity.User;
+
 public record UserLoginResponse(
-        UserDto userDto,
+        UserDto user,
         String apiKey,
         String accessToken
 ) {
+    /**
+     * 로그인 성공 시 User Entity와 토큰들을 Response DTO로 변환
+     *
+     * @param user 로그인한 사용자
+     * @param apiKey API 키
+     * @param accessToken 액세스 토큰
+     * @return UserLoginResponse DTO
+     */
+    public static UserLoginResponse of(User user, String apiKey, String accessToken) {
+        return new UserLoginResponse(
+                UserDto.from(user),
+                apiKey,
+                accessToken
+        );
+    }
 }

--- a/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.java
+++ b/backend/src/main/java/com/back/domain/user/user/dto/UserUpdateResponse.java
@@ -3,11 +3,19 @@ package com.back.domain.user.user.dto;
 import com.back.domain.user.user.entity.User;
 
 public record UserUpdateResponse(
+        Long id,
         String loginId,
         String email
 ) {
-    public UserUpdateResponse(User user) {
-        this(
+    /**
+     * 수정된 User Entity를 Response DTO로 변환
+     *
+     * @param user 수정된 User 엔티티
+     * @return UserUpdateResponse DTO
+     */
+    public static UserUpdateResponse from(User user) {
+        return new UserUpdateResponse(
+                user.getId(),
                 user.getLoginId(),
                 user.getEmail()
         );

--- a/backend/src/main/java/com/back/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/back/domain/user/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.back.domain.user.user.service;
 import com.back.domain.item.item.entity.Item;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.repository.UserRepository;
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.s3.S3ImageService;
 import jakarta.transaction.Transactional;
@@ -34,7 +35,7 @@ public class UserService {
         userRepository
                 .findByLoginId(loginId)
                 .ifPresent(_user -> {
-                    throw new ServiceException("409-1", "이미 존재하는 아이디입니다.");
+                    throw new ServiceException(ErrorCode.DUPLICATE_LOGIN_ID);
                 });
         password = passwordEncoder.encode(password); //패스워드 암호화 추가
 
@@ -50,7 +51,7 @@ public class UserService {
     @Transactional
     public void deleteById(Long id) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         List<String> imageUrls = user.getItems().stream()
                 .map(Item::getImgUrl)
@@ -66,7 +67,7 @@ public class UserService {
 
     public void checkPassword(User user, String password) {
         if (!passwordEncoder.matches(password, user.getPassword()))
-            throw new ServiceException("401-1", "비밀번호가 일치하지 않습니다.");
+            throw new ServiceException(ErrorCode.INVALID_PASSWORD);
     }
 
     public Optional<User> findByApiKey(String apiKey) {
@@ -89,7 +90,7 @@ public class UserService {
     @Transactional
     public User updateProfile(long id, @NotBlank @Size(min = 2, max = 30) String email) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         user.modifyUser(email, user.getPassword());
 
@@ -112,14 +113,14 @@ public class UserService {
             @NotBlank @Size(min = 2, max = 30) String currentPassword,
             @NotBlank @Size(min = 2, max = 20) String newPassword) {
         User user = userRepository.findById(id)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new ServiceException("403-1", "현재 비밀번호가 일치하지 않습니다.");
+            throw new ServiceException(ErrorCode.PASSWORD_MISMATCH);
         }
 
         if (passwordEncoder.matches(newPassword, user.getPassword())) {
-            throw new ServiceException("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+            throw new ServiceException(ErrorCode.SAME_PASSWORD);
         }
 
         String encodedPassword = passwordEncoder.encode(newPassword);

--- a/backend/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/back/global/exception/ErrorCode.java
@@ -1,0 +1,54 @@
+package com.back.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 400 Bad Request
+    INVALID_INPUT_VALUE("400-1", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_BODY("400-1", "요청 본문이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    SAME_PASSWORD("400-1", "새 비밀번호는 현재 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
+    INACTIVE_ITEM_CANNOT_REPLACE("400-2", "비활성 상태의 아이템은 교체할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    // 401 Unauthorized
+    LOGIN_REQUIRED("401-1", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_LOGIN_ID("401-1", "존재하지 않는 아이디입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_PASSWORD("401-1", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+    // 403 Forbidden
+    PASSWORD_MISMATCH("403-1", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    NO_PERMISSION("403-1", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // 404 Not Found
+    ITEM_NOT_FOUND("404-1", "존재하지 않는 아이템입니다.", HttpStatus.NOT_FOUND),
+    ITEM_NOT_FOUND_OR_NO_PERMISSION("404-1", "존재하지 않는 아이템이거나 권한이 없습니다.", HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND("404-1", "존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND),
+    CATEGORY_NOT_FOUND("404-1", "존재하지 않는 카테고리입니다.", HttpStatus.NOT_FOUND),
+    DATA_NOT_FOUND("404-1", "해당 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ONGOING_HISTORY_NOT_FOUND("404-1", "진행중인 이력이 없습니다.", HttpStatus.NOT_FOUND),
+    AI_ITEM_NOT_FOUND("404", "권장 주기를 찾을 수 없는 소모품입니다.", HttpStatus.NOT_FOUND),
+
+    // 409 Conflict
+    DUPLICATE_LOGIN_ID("409-1", "이미 존재하는 아이디입니다.", HttpStatus.CONFLICT),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR("500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_UPLOAD_FAILED("500-1", "이미지 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    EMAIL_SEND_FAILED("500-1", "메일 발송 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_TIMEOUT("500", "AI 응답 시간 초과", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_ERROR("500", "AI 처리 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_NO_RESPONSE("500", "AI로부터 응답을 받지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_INVALID_JSON("500", "AI 응답이 유효한 JSON 형식이 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    JSON_PARSING_ERROR("500", "JSON 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public String getMessageWithArgs(Object... args) {
+        return String.format(message, args);
+    }
+}

--- a/backend/src/main/java/com/back/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/back/global/exception/ServiceException.java
@@ -1,18 +1,52 @@
 package com.back.global.exception;
 
 import com.back.global.rsData.RsData;
+import lombok.Getter;
 
+@Getter
 public class ServiceException extends RuntimeException {
-    private final String resultCode;
-    private final String msg;
-    
+    private final ErrorCode errorCode;
+    private final String customMessage;
+
+    // ErrorCode만 사용하는 생성자
+    public ServiceException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.customMessage = null;
+    }
+
+    // 커스텀 메시지를 추가하는 생성자
+    public ServiceException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
+
+    // 메시지 포맷팅을 지원하는 생성자
+    public ServiceException(ErrorCode errorCode, Object... args) {
+        super(errorCode.getMessageWithArgs(args));
+        this.errorCode = errorCode;
+        this.customMessage = errorCode.getMessageWithArgs(args);
+    }
+
+    // 하위 호환성을 위한 생성자
+    @Deprecated
     public ServiceException(String resultCode, String msg) {
         super(resultCode + " : " + msg);
-        this.resultCode = resultCode;
-        this.msg = msg;
+        this.errorCode = null;
+        this.customMessage = msg;
     }
 
     public RsData<Void> getRsData() {
-        return new RsData<>(resultCode, msg, null);
+        if (errorCode != null) {
+            String message = customMessage != null ? customMessage : errorCode.getMessage();
+            return new RsData<>(errorCode.getCode(), message, null);
+        }
+        // 하위 호환성을 위한 fallback
+        return new RsData<>("500", customMessage, null);
+    }
+
+    public int getStatusCode() {
+        return errorCode != null ? errorCode.getHttpStatus().value() : 500;
     }
 }

--- a/backend/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.back.global.globalExceptionHandler;
 
+import com.back.global.exception.ErrorCode;
 import com.back.global.exception.ServiceException;
 import com.back.global.rsData.RsData;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -19,33 +22,55 @@ import java.util.stream.Collectors;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // 공통 예외 처리
     @ExceptionHandler(ServiceException.class)
-    public RsData<Void> handle(ServiceException ex, HttpServletResponse response) {
+    public ResponseEntity<RsData<Void>> handleServiceException(
+            ServiceException ex,
+            HttpServletResponse response
+    ) {
         RsData<Void> rsData = ex.getRsData();
-        ex.getMessage();
-        response.setStatus(rsData.statusCode());
-        return rsData;
+
+        // 로깅 추가
+        if (ex.getErrorCode() != null) {
+            log.warn("ServiceException 발생: code={}, message={}",
+                    ex.getErrorCode().getCode(),
+                    rsData.msg()
+            );
+        }
+
+        // HttpServletResponse의 상태 코드 설정은 ResponseEntity가 처리하므로 제거
+        HttpStatus httpStatus = ex.getErrorCode() != null
+                ? ex.getErrorCode().getHttpStatus()
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        return new ResponseEntity<>(rsData, httpStatus);
     }
 
     // 값이 존재하지 않을 때
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<RsData<Void>> handle(NoSuchElementException ex) {
+    public ResponseEntity<RsData<Void>> handleNoSuchElementException(NoSuchElementException ex) {
+        log.warn("NoSuchElementException 발생: {}", ex.getMessage());
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "404-1",
-                        "해당 데이터가 존재하지 않습니다."
+                        ErrorCode.DATA_NOT_FOUND.getCode(),
+                        ErrorCode.DATA_NOT_FOUND.getMessage()
                 ),
-                NOT_FOUND
+                ErrorCode.DATA_NOT_FOUND.getHttpStatus()
         );
     }
 
-    // 요청값 유효성 예외처리 (@Validated 붙은 클래스)
+    // @Validated 검증 실패 처리
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<RsData<Void>> handle(ConstraintViolationException ex) {
+    public ResponseEntity<RsData<Void>> handleConstraintViolationException(
+            ConstraintViolationException ex
+    ) {
+        log.warn("ConstraintViolationException 발생: {}", ex.getMessage());
+
         String message = ex.getConstraintViolations()
                 .stream()
                 .map(violation -> {
@@ -61,15 +86,20 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
                         message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
         );
     }
 
+    // @Valid 검증 실패 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<RsData<Void>> handle(MethodArgumentNotValidException ex) {
+    public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException ex
+    ) {
+        log.warn("MethodArgumentNotValidException 발생");
+
         String message = ex.getBindingResult()
                 .getAllErrors()
                 .stream()
@@ -81,38 +111,62 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
                         message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
         );
     }
 
-    // Json 형식이 올바르지 않을 때
+    // JSON 형식 오류 처리
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<RsData<Void>> handle(HttpMessageNotReadableException ex) {
+    public ResponseEntity<RsData<Void>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex
+    ) {
+        log.warn("HttpMessageNotReadableException 발생: {}", ex.getMessage());
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
-                        "요청 본문이 올바르지 않습니다."
+                        ErrorCode.INVALID_REQUEST_BODY.getCode(),
+                        ErrorCode.INVALID_REQUEST_BODY.getMessage()
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_REQUEST_BODY.getHttpStatus()
         );
     }
 
-    // 요청 헤더 값이 존재하지 않을 때
+    // 요청 헤더 누락 처리
     @ExceptionHandler(MissingRequestHeaderException.class)
-    public ResponseEntity<RsData<Void>> handle(MissingRequestHeaderException ex) {
+    public ResponseEntity<RsData<Void>> handleMissingRequestHeaderException(
+            MissingRequestHeaderException ex
+    ) {
+        log.warn("MissingRequestHeaderException 발생: {}", ex.getHeaderName());
+
+        String message = "%s-%s-%s".formatted(
+                ex.getHeaderName(),
+                "NotBlank",
+                ex.getLocalizedMessage()
+        );
+
         return new ResponseEntity<>(
                 new RsData<>(
-                        "400-1",
-                        "%s-%s-%s".formatted(
-                                ex.getHeaderName(),
-                                "NotBlank",
-                                ex.getLocalizedMessage()
-                        )
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
+                        message
                 ),
-                BAD_REQUEST
+                ErrorCode.INVALID_INPUT_VALUE.getHttpStatus()
+        );
+    }
+
+    // 예상치 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<RsData<Void>> handleException(Exception ex) {
+        log.error("Unexpected exception 발생", ex);
+
+        return new ResponseEntity<>(
+                new RsData<>(
+                        ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                        ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
+                ),
+                ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus()
         );
     }
 }

--- a/backend/src/test/java/com/back/domain/user/user/controller/ApiV1UserControllerTest.java
+++ b/backend/src/test/java/com/back/domain/user/user/controller/ApiV1UserControllerTest.java
@@ -64,6 +64,17 @@ public class ApiV1UserControllerTest {
     }
 
     @Test
+    @DisplayName("회원가입: 유효성검증실패-아이디누락")
+    void t1_2() throws Exception {
+        // BindingResult 없으므로 예외 발생을 테스트하면 됨
+        mvc.perform(post("/api/v1/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"test123\",\"email\":\"test@test.com\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"));
+    }
+
+    @Test
     @DisplayName("로그인")
     void t2() throws Exception {
         // 1. [준비] t1 데이터는 지워졌으므로, t2를 위해 다시 가입시켜야 합니다!

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -50,6 +50,42 @@ throw new ServiceException("500", "알 수 없는 에러");
 throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
 ```
 
+### 2.4 유효성 검증 (Validation) 처리 규칙
+
+본 프로젝트는 `@Valid` 어노테이션을 사용한 유효성 검증 시, 컨트롤러에서 `BindingResult`를 직접 핸들링하지 않습니다.
+
+#### **규칙**
+
+1. **`BindingResult` 파라미터 금지:** 컨트롤러 메서드 인자에 `BindingResult`를 선언하지 마세요.
+2. **자동 예외 발생:** 유효성 검증 실패 시 Spring이 자동으로 `MethodArgumentNotValidException`을 발생시킵니다.
+3. **전역 처리:** `GlobalExceptionHandler`가 해당 예외를 잡아 표준 에러 응답(`RsData`)으로 변환합니다.
+
+#### **코드 예시**
+
+**지양 (Legacy: 직접 처리 방식)**
+
+```java
+@PostMapping("/signup")
+public RsData<UserDto> join(@Valid @RequestBody UserJoinRequest req, BindingResult bindingResult) {
+    if (bindingResult.hasErrors()) {
+        return new RsData<>("400", bindingResult.getFieldError().getDefaultMessage());
+    }
+    // ...
+}
+```
+
+**권장 (New Standard: 전역 처리 방식)**
+
+```java
+@PostMapping("/signup")
+public RsData<UserDto> join(@Valid @RequestBody UserJoinRequest req) {
+    // 유효성 검증 실패 시, 이곳에 도달하지 않고 GlobalExceptionHandler로 넘어갑니다.
+    User user = userService.join(...);
+    return new RsData<>("201", "성공", ...);
+}
+```
+---
+
 ## 3. 응답 포맷
    클라이언트는 항상 아래와 같은 JSON 형태의 `RsData` 응답을 받게 됩니다.
 

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -1,0 +1,65 @@
+# 백엔드 예외 처리 가이드 (Exception Handling Guide)
+본 프로젝트는 예외 처리를 일관성 있게 관리하기 위해 `ErrorCode` Enum과 `ServiceException`을 사용합니다. 새로운 예외를 추가하거나 사용할 때 아래 가이드를 따라주세요.
+
+## 1. 아키텍처 개요
+- **ErrorCode**: 에러 코드(`String`), 메시지(`String`), HTTP 상태(`HttpStatus`)를 정의하는 Enum입니다. 
+- **ServiceException**: 비즈니스 로직에서 발생하는 체크 예외(Runtime)를 감싸는 커스텀 예외 클래스입니다. 
+- **GlobalExceptionHandler**: 전역에서 발생하는 예외를 잡아 표준 응답(`RsData`)으로 변환합니다.
+
+## 2. 사용 방법
+### 2.1 예외 정의하기 (`ErrorCode.java`)
+새로운 에러가 필요하면 `ErrorCode` Enum에 상수를 추가합니다. 네이밍 규칙은 `도메인_상세이유` 또는 `상황설명` (Snake Case)을 권장합니다.
+
+```Java
+public enum ErrorCode {
+// ... 기존 코드 ...
+
+    // [신규 추가] 
+    // 형식: 이름("에러코드", "메시지", HttpStatus)
+    COUPON_ALREADY_USED("409-2", "이미 사용된 쿠폰입니다.", HttpStatus.CONFLICT),
+    
+    // ...
+}
+```
+### 2.2 예외 발생시키기 (Service Layer)
+비즈니스 로직에서 예외 상황이 발생하면 `ServiceException`을 던집니다.
+
+**Case 1: 단순 에러 발생**
+
+```Java
+// 아이템을 찾을 수 없을 때
+Item item = itemRepository.findById(id)
+.orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND));
+```
+
+**Case 2: 동적 메시지 사용** 메시지에 변수(ID, 이름 등)를 포함해야 한다면 `ErrorCode` 메시지에 `%s` 포맷팅을 사용하고 인자를 전달합니다.
+
+```Java
+// ErrorCode 정의: "존재하지 않는 게시글입니다 (ID: %s)"
+throw new ServiceException(ErrorCode.POST_NOT_FOUND, postId);
+```
+
+### 2.3 하위 호환성 (주의사항)
+현재 리팩토링 과도기이므로 문자열을 직접 입력하는 생성자(`deprecated`)가 남아있으나, **신규 코드 작성 시에는 반드시 `ErrorCode`를 사용해야 합니다.**
+
+```Java
+// 지양해주세요 (Legacy)
+throw new ServiceException("500", "알 수 없는 에러");
+
+// 권장합니다
+throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+```
+
+## 3. 응답 포맷
+   클라이언트는 항상 아래와 같은 JSON 형태의 `RsData` 응답을 받게 됩니다.
+
+```JSON
+{
+"resultCode": "404-1",
+"msg": "존재하지 않는 아이템입니다.",
+"data": null
+}
+```
+
+## 4. 로깅
+   `GlobalExceptionHandler`에서 `ServiceException` 발생 시 WARN 레벨로 로그가 기록됩니다. 디버깅 시 서버 로그를 확인해 주세요.

--- a/docs/service-layer.md
+++ b/docs/service-layer.md
@@ -1,0 +1,62 @@
+# 🏗️ 서비스 계층 아키텍처 가이드
+
+본 프로젝트는 **단일 책임 원칙(SRP)**을 준수하여, 하나의 서비스 클래스가 너무 많은 책임을 갖지 않도록 기능을 분리합니다.
+
+## 1. 서비스 분리 원칙
+
+비즈니스 로직이 비대해지거나 성격이 다른 기능이 혼재될 경우, 아래 기준에 따라 별도의 서비스 클래스로 추출(Extract Class)합니다.
+
+| 서비스 종류 | 역할 및 책임 | 명명 규칙 | 예시 |
+| --- | --- | --- | --- |
+| **Core Service** | 도메인의 핵심 **CRUD** 및 상태 변경 로직 | `[Domain]Service` | `ItemService` |
+| **Statistics Service** | 복잡한 **통계/집계** 조회 (Read-Only 권장) | `[Domain]StatisticsService` | `ItemStatisticsService` |
+| **External Service** | **외부 API** (AI, 결제, 메일) 연동 및 예외 처리 | `[Domain][Feature]Service` | `ItemRecommendationService` |
+
+## 2. 모범 사례 (Best Practices)
+
+### 2.1 핵심 비즈니스 로직 (Core)
+
+* 가장 빈번하게 사용되는 조회, 생성, 수정, 삭제 로직을 담당합니다.
+* 트랜잭션(`@Transactional`) 관리가 필수적입니다.
+* **예시:** `ItemService` (아이템 생성, 교체, 활성화 토글)
+
+### 2.2 외부 시스템 연동 (External/AI)
+
+* 실행 시간이 길거나 실패 가능성이 높은 로직(AI, S3, 외부 API)은 핵심 로직과 분리합니다.
+* **타임아웃(Timeout)** 설정과 **별도의 예외 처리(Try-Catch)**가 필수입니다.
+* **예시:** `ItemRecommendationService` (Gemini AI 연동)
+```java
+// 외부 서비스는 핵심 로직(ItemService)과 분리하여 독립적으로 실패를 제어함
+public Recommendation getRecommendation(...) {
+    try {
+        // 외부 API 호출
+    } catch (TimeoutException e) {
+        // 타임아웃 처리
+    }
+}
+```
+
+
+
+### 2.3 통계 및 조회 전용 (Statistics)
+
+* 단순 CRUD가 아닌 복잡한 `Group By`, `Join` 등이 포함된 조회 로직을 담당합니다.
+* 데이터 변경이 없으므로 `@Transactional(readOnly = true)`를 기본으로 사용합니다.
+* **예시:** `ItemStatisticsService` (카테고리별 평균 사용일, 교체 순위 조회)
+
+## 3. 컨트롤러에서의 사용 (Facade Pattern)
+
+컨트롤러(`Controller`)는 필요한 여러 서비스를 주입받아 조합(Composition)하여 사용합니다.
+
+```java
+@RestController
+@RequiredArgsConstructor
+public class ItemController {
+    // 성격에 따라 분리된 서비스들을 각각 주입받음
+    private final ItemService itemService;                  // 1. CRUD
+    private final ItemStatisticsService itemStatisticsService; // 2. 통계
+    private final ItemRecommendationService itemRecommendationService; // 3. AI
+    
+    // ...
+}
+```


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #216 

---

#### **1. 작업 내용**

기존에 **CRUD, 통계 조회, AI 추천** 등 서로 다른 성격의 비즈니스 로직을 모두 담당하던 비대한 `ItemService`를 기능별로 3개의 서비스로 분리
이를 통해 코드의 응집도를 높이고 유지보수성을 개선

#### **2. 주요 변경 사항**

**A. 서비스 클래스 분리**

* **`ItemService` (기존 유지, 축소)**
* 순수한 **아이템 CRUD** (생성, 조회, 수정, 삭제) 및 상태 관리(교체, 활성화 토글) 책임


* **`ItemStatisticsService` (신규 생성)**
  * `getCategoryAverageUsage`, `getMostReplacedItems` 등 **통계 관련 조회 로직**을 전담


* **`ItemRecommendationService` (신규 생성)**
  * `getItemCycleRecommend` 등 **Gemini AI 연동 로직**을 전담
  * AI API 호출, 타임아웃 처리, JSON 파싱 및 예외 처리 로직을 이곳으로 캡슐화

**B. 컨트롤러 의존성 변경 (`ItemController`)**

* 기존에는 `ItemService` 하나만 주입받았으나, 리팩토링 후 각 기능에 맞는 서비스를 주입받아 사용하도록 변경

#### **3. 변경 전/후 비교 (Comparison)**

**Controller Dependency Injection**

```java
// Before
private final ItemService itemService;

// After
private final ItemService itemService; // CRUD
private final ItemStatisticsService itemStatisticsService; // 통계
private final ItemRecommendationService itemRecommendationService; // AI 추천

```

**Service Logic Separation**

* **AI Logic:** `ItemService`에 있던 복잡한 `Gemini Client` 호출 및 `try-catch` 예외 처리 코드가 `ItemRecommendationService`로 이동
* **Statistics Logic:** 통계 쿼리 호출 로직이 `ItemStatisticsService`로 이동하여 `ItemService`의 비즈니스 로직이 명확

#### **4. 변경 이유 (Motivation)**

* **단일 책임 원칙(SRP) 준수:** `ItemService`가 너무 많은 역할을 수행하고 있어, 기능 수정 시 영향 범위를 파악하기 어려움
* **외부 의존성 격리:** AI 추천 기능(Gemini API)은 외부 네트워크 통신과 타임아웃 등 실패 가능성이 높은 로직이라 핵심 CRUD 로직과 분리하여 안정성을 높이고자 함
* **가독성 향상:** 각 서비스 클래스가 자신의 이름에 맞는 역할만 수행하므로 코드를 이해하기 쉬워짐