### PR TITLE
Feat: [BACK] 아이템 이력 조회 소유권 검증 및 데이터 격리 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "4.0.1"
     id("io.spring.dependency-management") version "1.1.7"
+    id("jacoco") // 코드 커버리지 측정
 }
 
 group = "com"
@@ -11,6 +12,59 @@ description = "backend"
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+// JaCoCo 도구 버전 명시
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.test {
+    useJUnitPlatform()
+    ignoreFailures = true // 테스트가 실패해도 빌드를 계속 진행 (리포트 생성 가능)
+    finalizedBy(tasks.jacocoTestReport) // 테스트 task가 끝나면 jacocoTestReport 실행
+}
+
+// 리포트 설정 및 불필요한 파일 제외
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // 리포트 생성 전 테스트가 먼저 실행되어야 함
+
+    reports {
+        xml.required.set(true)  // CI/CD 툴(SonarQube 등)에서 분석할 때 필요
+        html.required.set(true) // 사람이 브라우저로 볼 때 필요
+    }
+
+    // 커버리지 측정에서 제외할 클래스들 설정 (Lombok, DTO, 설정파일 등)
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/dto/**",           // DTO는 로직이 없으므로 제외
+                    "**/entity/**",        // QClass 등 제외 (필요시)
+                    "**/config/**",        // 설정 파일 제외
+                    "**/global/**",        // 전역 설정/예외 등 제외 (선택 사항)
+                    "**/*Application*",    // 메인 애플리케이션 클래스 제외
+                    "**/Q*",               // QueryDSL Q-Type 제외
+                )
+            }
+        })
+    )
+}
+
+// 커버리지 커트라인 설정: 기준 미달 시 빌드 실패
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            element = "CLASS"
+            // 브랜치 커버리지 0% 이상 (최소한의 설정 예시)
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.00".toBigDecimal()
+            }
+        }
     }
 }
 

--- a/backend/src/main/java/com/back/domain/item/item/entity/Item.java
+++ b/backend/src/main/java/com/back/domain/item/item/entity/Item.java
@@ -26,6 +26,7 @@ public class Item {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY) // category(1) : item(N)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     private String name;

--- a/backend/src/main/java/com/back/domain/item/itemHistory/controller/ItemHistoryController.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/controller/ItemHistoryController.java
@@ -38,8 +38,9 @@ public class ItemHistoryController {
     @GetMapping("/{itemId}/histories")
     @Operation(summary = "특정 아이템의 교체 이력 조회", description = "특정 아이템의 이력을 조회합니다.")
     public RsData<List<ItemHistoryResponse>> getItemHistories(@PathVariable Long itemId) {
+        Long userId = rq.getMemberId();
         // Service에서 이미 변환된 DTO 리스트를 반환
-        List<ItemHistoryResponse> histories = itemHistoryService.getItemHistories(itemId);
+        List<ItemHistoryResponse> histories = itemHistoryService.getItemHistories(itemId, userId);
 
         return new RsData<>("200-1", "아이템 이력 조회 성공", histories);
     }

--- a/backend/src/main/java/com/back/domain/item/itemHistory/repository/ItemHistoryRepository.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/repository/ItemHistoryRepository.java
@@ -17,7 +17,7 @@ public interface ItemHistoryRepository extends JpaRepository<ItemHistory, Long> 
             SELECT ih
             FROM ItemHistory ih
             JOIN FETCH ih.item i
-            JOIN FETCH i.category c
+            LEFT JOIN FETCH i.category c
             WHERE i.user.id = :userId
             ORDER BY ih.startDate DESC
             """)

--- a/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.java
+++ b/backend/src/main/java/com/back/domain/item/itemHistory/service/ItemHistoryService.java
@@ -1,6 +1,7 @@
 package com.back.domain.item.itemHistory.service;
 
 import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.repository.ItemRepository;
 import com.back.domain.item.itemHistory.dto.ItemAllHistoryResponse;
 import com.back.domain.item.itemHistory.dto.ItemHistoryResponse;
 import com.back.domain.item.itemHistory.entity.ItemHistory;
@@ -18,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ItemHistoryService {
     private final ItemHistoryRepository itemHistoryRepository;
+    private final ItemRepository itemRepository;
 
     @Transactional
     public void createItemHistory(Item item) {
@@ -26,7 +28,9 @@ public class ItemHistoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<ItemHistoryResponse> getItemHistories(Long itemId) {
+    public List<ItemHistoryResponse> getItemHistories(Long itemId, Long userId) {
+        itemRepository.findByIdAndUserId(itemId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.ITEM_NOT_FOUND_OR_NO_PERMISSION));
         List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(itemId);
         return ItemHistoryResponse.fromList(histories);
     }

--- a/backend/src/test/java/com/back/domain/item/itemHistory/controller/ItemHistoryControllerTest.java
+++ b/backend/src/test/java/com/back/domain/item/itemHistory/controller/ItemHistoryControllerTest.java
@@ -1,9 +1,14 @@
 package com.back.domain.item.itemHistory.controller;
 
-import com.back.domain.item.itemHistory.dto.ItemAllHistoryResponse;
+import com.back.domain.category.category.entity.Category;
+import com.back.domain.category.category.repository.CategoryRepository;
+import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.repository.ItemRepository;
 import com.back.domain.item.itemHistory.service.ItemHistoryService;
 import com.back.domain.user.user.entity.User;
 import com.back.domain.user.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,55 +20,199 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.LocalDate;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
-@AutoConfigureMockMvc
 @Transactional
-public class ItemHistoryControllerTest {
-    @Autowired
-    private MockMvc mvc;
-    @Autowired
-    private ItemHistoryService itemHistoryService;
-    @Autowired
-    private UserService userService;
+@AutoConfigureMockMvc
+class ItemHistoryControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired UserService userService;
+    @Autowired ItemRepository itemRepository;
+    @Autowired CategoryRepository categoryRepository;
+    @Autowired ItemHistoryService itemHistoryService;
+
+    private User user;
+    private Item item;
+
+    // 로그인 후 인증 쿠키를 발급받는 헬퍼 메서드
+    private Cookie loginAndGetCookie(String loginId, String password) throws Exception {
+        ResultActions result = mvc.perform(
+                post("/api/v1/user/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "loginId": "%s",
+                                    "password": "%s"
+                                }
+                                """.formatted(loginId, password))
+        );
+        Cookie cookie = result.andReturn().getResponse().getCookie("accessToken");
+        assert cookie != null;
+        return cookie;
+    }
+
+    // 각 테스트 실행 전 기본 사용자, 카테고리, 아이템 데이터 초기화
+    @BeforeEach
+    void setUp() {
+        user = userService.join("historyUser", "1234", "history@test.com");
+        Category category = categoryRepository.save(new Category("칫솔"));
+        item = itemRepository.save(new Item(
+                user, category, "테스트 칫솔", "https://img.example.com/test.jpg",
+                LocalDate.of(2024, 1, 1), "30", LocalDate.of(2024, 1, 31), true
+        ));
+    }
 
     @Test
-    @DisplayName("전체 아이템 이력 조회")
-    void getAllItemHistories_success() throws Exception {
-        User user = userService.findByLoginId("user1").get();
-        String apiKey = user.getApiKey();
+    @DisplayName("전체 이력 조회 - 성공: 이력이 없어도 빈 배열로 응답")
+    void getAllHistories_empty() throws Exception {
+        // 로그인 쿠키 획득
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/v1/items/histories")
-                                .header("Authorization", "Bearer " + apiKey)
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print());
-
-        List<ItemAllHistoryResponse> list = itemHistoryService.getAllItemHistories(user.getId());
-
-        resultActions
-                .andExpect(handler().handlerType(ItemHistoryController.class))
-                .andExpect(handler().methodName("getAllItemHistories"))
+        // 이력이 없는 상태에서 전체 조회 요청 시 200 OK와 빈 배열 반환 검증
+        mvc.perform(get("/api/v1/items/histories").cookie(cookie))
+                .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200"))
-                .andExpect(jsonPath("$.msg").value("전체 아이템 이력 조회 성공"))
-                .andExpect(jsonPath("$.data.length()").value(list.size()));
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
 
-        for (int i = 0; i < list.size(); i++) {
-            ItemAllHistoryResponse itemHistory = list.get(i);
-            resultActions
-                    .andExpect(jsonPath("$.data.[%d].id".formatted(i)).value(itemHistory.id()))
-                    .andExpect(jsonPath("$.data.[%d].itemId".formatted(i)).value(itemHistory.itemId()))
-                    .andExpect(jsonPath("$.data.[%d].itemName".formatted(i)).value(itemHistory.itemName()))
-                    .andExpect(jsonPath("$.data.[%d].startDate".formatted(i)).value(itemHistory.startDate().toString()));
-        }
+    @Test
+    @DisplayName("전체 이력 조회 - 성공: 이력 존재 시 데이터 반환")
+    void getAllHistories_withData() throws Exception {
+        // 아이템 이력 생성
+        itemHistoryService.createItemHistory(item);
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 조회 요청 시 생성된 이력 데이터가 올바르게 반환되는지 검증
+        mvc.perform(get("/api/v1/items/histories").cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].itemName").value(item.getName()))
+                .andExpect(jsonPath("$.data[0].categoryName").value(item.getCategory().getName()))
+                .andExpect(jsonPath("$.data[0].startDate").value(item.getStartDate().toString()));
+    }
+
+    @Test
+    @DisplayName("전체 이력 조회 - 성공: 다른 유저의 이력은 포함되지 않는다")
+    void getAllHistories_isolatedByUser() throws Exception {
+        // 다른 유저 및 해당 유저의 아이템 이력 생성
+        User other = userService.join("otherUser", "1234", "other@test.com");
+        Category otherCategory = categoryRepository.save(new Category("기타 카테고리"));
+        Item otherItem = itemRepository.save(new Item(
+                other, otherCategory, "다른 칫솔", null,
+                LocalDate.of(2024, 2, 1), "30", LocalDate.of(2024, 3, 2), true
+        ));
+        itemHistoryService.createItemHistory(otherItem);
+
+        // 내 아이템 이력 생성
+        itemHistoryService.createItemHistory(item);
+
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 내 이력만 조회되고 다른 유저의 이력은 포함되지 않는지 검증 (데이터 격리)
+        mvc.perform(get("/api/v1/items/histories").cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].itemName").value(item.getName()));
+    }
+
+    @Test
+    @DisplayName("전체 이력 조회 - 실패: 비로그인 시 403 Forbidden")
+    void getAllHistories_unauthorized() throws Exception {
+        // 쿠키 없이 요청 시 403 에러 발생 검증
+        mvc.perform(get("/api/v1/items/histories"))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: 이력이 없으면 빈 배열 반환")
+    void getItemHistories_empty() throws Exception {
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 특정 아이템 ID로 조회했으나 이력이 없을 경우 빈 배열 반환 검증
+        mvc.perform(get("/api/v1/items/{itemId}/histories", item.getId()).cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: 이력 존재 시 데이터 반환")
+    void getItemHistories_withData() throws Exception {
+        // 이력 생성
+        itemHistoryService.createItemHistory(item);
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 특정 아이템 조회 시 이력 정보가 올바르게 매핑되는지 검증
+        mvc.perform(get("/api/v1/items/{itemId}/histories", item.getId()).cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].itemId").value(item.getId()))
+                .andExpect(jsonPath("$.data[0].startDate").value(item.getStartDate().toString()));
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: 여러 이력이 startDate 내림차순으로 반환된다")
+    void getItemHistories_sorted() throws Exception {
+        // 동일 아이템에 대해 2개의 이력 생성
+        itemHistoryService.createItemHistory(item);
+        itemHistoryService.createItemHistory(item);
+
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 2개의 데이터가 반환되는지 확인 (내림차순 정렬 로직은 Service 테스트에서 상세 검증)
+        mvc.perform(get("/api/v1/items/{itemId}/histories", item.getId()).cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 실패: 존재하지 않는 itemId이면 404 예외 발생")
+    void getItemHistories_notExistItem() throws Exception {
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // DB에 없는 ID 조회 시 404 Not Found 에러 발생 검증
+        mvc.perform(get("/api/v1/items/{itemId}/histories", 999999L).cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").exists());
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 실패: 다른 유저의 아이템을 조회하면 404/403 예외 발생 (데이터 격리)")
+    void getItemHistories_otherUserItem() throws Exception {
+        // 다른 유저와 그의 아이템 및 이력 생성
+        User other = userService.join("otherUser", "1234", "other@test.com");
+        Category otherCategory = categoryRepository.save(new Category("기타"));
+        Item otherItem = itemRepository.save(new Item(
+                other, otherCategory, "남의 아이템", null,
+                LocalDate.now(), "30", LocalDate.now(), true
+        ));
+        itemHistoryService.createItemHistory(otherItem);
+
+        Cookie cookie = loginAndGetCookie("historyUser", "1234");
+
+        // 내 계정으로 남의 아이템 이력을 조회 시도 시 예외(404 Not Found 등) 발생 검증
+        mvc.perform(get("/api/v1/items/{itemId}/histories", otherItem.getId()).cookie(cookie))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").exists());
     }
 }

--- a/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.java
+++ b/backend/src/test/java/com/back/domain/item/itemHistory/service/ItemHistoryServiceTest.java
@@ -1,0 +1,226 @@
+package com.back.domain.item.itemHistory.service;
+
+import com.back.domain.category.category.entity.Category;
+import com.back.domain.category.category.repository.CategoryRepository;
+import com.back.domain.item.item.entity.Item;
+import com.back.domain.item.item.repository.ItemRepository;
+import com.back.domain.item.itemHistory.dto.ItemAllHistoryResponse;
+import com.back.domain.item.itemHistory.dto.ItemHistoryResponse;
+import com.back.domain.item.itemHistory.entity.ItemHistory;
+import com.back.domain.item.itemHistory.repository.ItemHistoryRepository;
+import com.back.domain.user.user.entity.User;
+import com.back.domain.user.user.repository.UserRepository;
+import com.back.global.exception.ServiceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ItemHistoryServiceTest {
+
+    @Autowired ItemHistoryService itemHistoryService;
+    @Autowired ItemHistoryRepository itemHistoryRepository;
+    @Autowired ItemRepository itemRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired CategoryRepository categoryRepository;
+
+    private User user;
+    private Category category;
+    private Item item;
+
+    // 각 테스트 실행 전 필요한 유저, 카테고리, 아이템 데이터를 미리 생성 및 저장
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(new User("testuser", "1234", "test@test.com"));
+        category = categoryRepository.save(new Category("칫솔"));
+        item = itemRepository.save(new Item(
+                user, category, "테스트 칫솔", "https://img.example.com/test.jpg",
+                LocalDate.of(2024, 1, 1), "30", LocalDate.of(2024, 1, 31), true
+        ));
+    }
+
+
+    @Test
+    @DisplayName("이력 생성 - 성공: item의 startDate로 이력이 생성된다")
+    void createItemHistory_success() {
+        // 아이템 이력 생성 요청
+        itemHistoryService.createItemHistory(item);
+
+        // 생성된 이력을 조회하여 시작일이 아이템의 시작일과 일치하고, 종료일은 null인지 검증
+        List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(item.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getStartDate()).isEqualTo(item.getStartDate());
+        assertThat(histories.get(0).getEndDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("이력 생성 - 성공: 여러 번 호출 시 각각 저장된다")
+    void createItemHistory_multiple() {
+        // 이력 생성을 2회 호출
+        itemHistoryService.createItemHistory(item);
+        itemHistoryService.createItemHistory(item);
+
+        // 각각 별도의 레코드로 저장되어 총 2개의 이력이 존재하는지 확인
+        List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(item.getId());
+        assertThat(histories).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
+    void getItemHistories_empty() {
+        // 이력이 없는 상태에서 조회 시 빈 리스트가 반환되는지 확인
+        List<ItemHistoryResponse> responses = itemHistoryService.getItemHistories(item.getId(), user.getId());        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: DTO에 올바른 데이터가 담긴다")
+    void getItemHistories_dto_mapping() {
+        // 이력 생성 후 조회
+        itemHistoryService.createItemHistory(item);
+        List<ItemHistoryResponse> responses = itemHistoryService.getItemHistories(item.getId(), user.getId());
+
+        // 조회된 DTO가 아이템 ID, 시작일 등 데이터를 올바르게 매핑했는지 검증
+        assertThat(responses).hasSize(1);
+        ItemHistoryResponse response = responses.get(0);
+        assertThat(response.itemId()).isEqualTo(item.getId());
+        assertThat(response.startDate()).isEqualTo(item.getStartDate());
+        assertThat(response.endDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 성공: startDate 내림차순으로 정렬된다")
+    void getItemHistories_sorted() {
+        // 시간차를 두고 이력 2개 생성
+        itemHistoryService.createItemHistory(item);
+        itemHistoryService.createItemHistory(item);
+
+        // 조회 시 최신순(시작일 내림차순)으로 정렬되어 반환되는지 확인
+        List<ItemHistoryResponse> responses = itemHistoryService.getItemHistories(item.getId(), user.getId());
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).startDate())
+                .isAfterOrEqualTo(responses.get(1).startDate());
+    }
+
+    @Test
+    @DisplayName("전체 아이템 이력 조회 - 성공: 이력이 없으면 빈 리스트 반환")
+    void getAllItemHistories_empty() {
+        // 유저의 모든 아이템 이력 조회 시 데이터가 없으면 빈 리스트 반환 검증
+        List<ItemAllHistoryResponse> responses = itemHistoryService.getAllItemHistories(user.getId());
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("전체 아이템 이력 조회 - 성공: 해당 유저의 이력만 반환된다")
+    void getAllItemHistories_onlyMine() {
+        // 내 아이템 이력 생성
+        itemHistoryService.createItemHistory(item);
+
+        // 다른 유저 및 아이템 이력 생성
+        User otherUser = userRepository.save(new User("other", "1234", "other@test.com"));
+        Item otherItem = itemRepository.save(new Item(
+                otherUser, category, "다른유저 칫솔", null,
+                LocalDate.of(2024, 2, 1), "30", LocalDate.of(2024, 3, 2), true
+        ));
+        itemHistoryService.createItemHistory(otherItem);
+
+        // 내 이력 조회 시, 다른 유저의 데이터는 제외되고 내 데이터만 조회되는지 확인
+        List<ItemAllHistoryResponse> responses = itemHistoryService.getAllItemHistories(user.getId());
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).itemName()).isEqualTo(item.getName());
+        assertThat(responses.get(0).itemId()).isEqualTo(item.getId());
+    }
+
+    @Test
+    @DisplayName("전체 아이템 이력 조회 - 성공: DTO에 카테고리명·아이템명·imgUrl이 담긴다")
+    void getAllItemHistories_dto_mapping() {
+        itemHistoryService.createItemHistory(item);
+
+        List<ItemAllHistoryResponse> responses = itemHistoryService.getAllItemHistories(user.getId());
+
+        // 전체 이력 DTO에 카테고리 이름, 이미지 URL 등이 포함되어 있는지 검증
+        assertThat(responses).hasSize(1);
+        ItemAllHistoryResponse res = responses.get(0);
+
+        assertThat(res.itemId()).isEqualTo(item.getId());
+        assertThat(res.itemName()).isEqualTo(item.getName());
+        assertThat(res.categoryName()).isEqualTo(category.getName());
+        assertThat(res.imgUrl()).isEqualTo(item.getImgUrl());
+        assertThat(res.startDate()).isEqualTo(item.getStartDate());
+        assertThat(res.endDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("이력 종료 - 성공: endDate가 올바르게 설정된다")
+    void endHistory_success() {
+        // 이력 생성 및 종료일 설정
+        itemHistoryService.createItemHistory(item);
+        LocalDate endDate = item.getStartDate().plusDays(30);
+
+        // 이력 종료 처리
+        itemHistoryService.endHistory(item.getId(), endDate);
+
+        // DB에서 해당 이력의 종료일이 올바르게 업데이트되었는지 확인
+        List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(item.getId());
+        assertThat(histories.get(0).getEndDate()).isEqualTo(endDate);
+    }
+
+    @Test
+    @DisplayName("이력 종료 - 성공: 종료 후 usedDays가 올바르게 계산된다")
+    void endHistory_usedDays() {
+        // 이력 생성
+        itemHistoryService.createItemHistory(item);
+        LocalDate endDate = item.getStartDate().plusDays(10);
+
+        // 10일 뒤 날짜로 이력 종료
+        itemHistoryService.endHistory(item.getId(), endDate);
+
+        // 사용 일수(usedDays)가 10일로 계산되어 저장되었는지 검증
+        List<ItemHistory> histories = itemHistoryRepository.findByItemIdOrderByStartDateDesc(item.getId());
+        assertThat(histories.get(0).getUsedDays()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("이력 종료 - 실패: 진행 중인 이력이 없으면 ServiceException 발생")
+    void endHistory_fail_noOngoing() {
+        // 진행 중인 이력이 없는 상태에서 종료를 시도하면 예외 발생 확인
+        assertThatThrownBy(() -> itemHistoryService.endHistory(item.getId(), LocalDate.now()))
+                .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("이력 종료 - 실패: 이미 종료된 이력만 있을 때 ServiceException 발생")
+    void endHistory_fail_alreadyEnded() {
+        // 이력을 생성하고 이미 종료된 상태로 만듦
+        itemHistoryService.createItemHistory(item);
+        itemHistoryService.endHistory(item.getId(), LocalDate.of(2024, 1, 15));
+
+        // 이미 종료된 상태에서 다시 종료를 시도하면 예외 발생 확인
+        assertThatThrownBy(() -> itemHistoryService.endHistory(item.getId(), LocalDate.now()))
+                .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("특정 아이템 이력 조회 - 실패: 내 아이템이 아니면 ServiceException 발생")
+    void getItemHistories_fail_notMyItem() {
+        User stranger = userRepository.save(new User("stranger", "1234", "stranger@test.com"));
+
+        // 다른 유저(stranger)가 내 아이템의 이력을 조회하려 할 때 예외(권한 없음) 발생 확인
+        assertThatThrownBy(() ->
+                itemHistoryService.getItemHistories(item.getId(), stranger.getId())
+        ).isInstanceOf(ServiceException.class);
+    }
+}


### PR DESCRIPTION
<!--
PR 제목은 이슈와 동일하게 "키워드: 작업 내용"으로 등록해 주세요!
-->

## #️⃣연관된 이슈

close #225 

---

## 작업 내용

기존 아이템 이력 조회 API(`GET /api/v1/items/{itemId}/histories`)는 아이템 ID만 알면 타인의 이력을 조회할 수 있는 보안 취약점이 있음
이를 해결하기 위해 **로그인한 사용자가 해당 아이템의 실소유주인지 검증하는 로직**을 추가하여 데이터 격리(Data Isolation)를 구현

### **작업 상세 내용**

**1. Backend Logic**

* **`ItemHistoryController`**: `Rq` 객체를 통해 현재 로그인한 사용자의 `userId`를 추출하여 Service로 전달하도록 수정
* **`ItemHistoryService`**:
* `getItemHistories` 메서드 시그니처에 `userId` 파라미터를 추가
* `itemRepository.findByIdAndUserId(itemId, userId)`를 호출하여, 아이템이 존재하지 않거나 타인의 아이템인 경우 예외(`ServiceException`)를 발생시키도록 변경



**2. Repository Query**

* **`ItemHistoryRepository`**: 전체 이력 조회 쿼리에서 `JOIN FETCH`를 **`LEFT JOIN FETCH`**로 변경
*  `Category` 데이터가 누락된 예외적인 상황에서도 아이템 이력 자체는 정상적으로 조회되도록 방어적 코딩을 적용.

**3. Test Code**

* **`ItemHistoryControllerTest`**:
* 타인의 아이템 ID로 조회 시 `404 Not Found`(보안상 존재하지 않음으로 처리) 또는 예외가 발생하는지 확인하는 보안 테스트(`getItemHistories_otherUserItem`)를 추가
* 기존 "이력이 없으면 빈 배열 반환" 로직이 "권한 없으면 예외 발생"으로 변경됨에 따라 검증 코드를 `expect(status().isNotFound())` 등으로 수정


* **`ItemHistoryServiceTest`**:
* 메서드 시그니처 변경(`userId` 추가)을 모든 테스트 케이스에 반영
* 타인의 아이템 조회 시 `ServiceException`이 발생하는지 검증하는 단위 테스트를 추가

---

### **트러블 슈팅 (Troubleshooting)**

#### **1. `JOIN FETCH`로 인한 데이터 조회 누락**

* **문제**: 테스트 환경에서 `Category`가 `null`인 아이템을 생성하여 이력을 조회했을 때, DB에 데이터가 있음에도 조회 결과가 `0`건으로 나오는 현상이 발생
* **원인**: 기존 JPQL이 `JOIN FETCH i.category` (Inner Join)를 사용하고 있어, 카테고리가 없는 아이템은 교집합 조건에 맞지 않아 결과에서 제외
* **해결**: 데이터 무결성이 깨진 상황에서도 이력은 조회될 수 있도록 **`LEFT JOIN FETCH`**로 쿼리를 수정하여 해결

#### **2. 소유권 검증 로직 변경에 따른 테스트 실패**

* **문제**: 타인의 아이템 이력을 조회하는 테스트(`getItemHistories_otherUserItem`)에서 `200 OK`와 빈 배열(`[]`)을 기대했으나, 실제로는 예외가 발생하며 테스트가 실패
* **원인**: 보안 강화를 위해 "권한이 없으면 빈 값 반환"하던 기존 정책을 **"권한이 없으면 예외 발생(404/403)"**으로 변경했기 때문에 발생한 정합성 문제
* **해결**: Controller 테스트 코드를 수정하여, 타인의 아이템 조회 시 에러 응답(404 Not Found)이 반환되는 것을 검증하는 것으로 변경

#### **3. 메서드 시그니처 변경에 따른 컴파일 오류**

* **문제**: `ItemHistoryService.getItemHistories`에 `userId` 파라미터를 추가하면서, 이를 호출하던 기존의 모든 테스트 코드에서 파라미터 개수 불일치 오류가 발생
* **해결**: `ItemHistoryController` 및 `ItemHistoryServiceTest`의 모든 호출부에 `user.getId()`를 주입하도록 일괄 수정하여 컴파일 오류를 해결

## 작업 전
<img width="1195" height="399" alt="image" src="https://github.com/user-attachments/assets/29fe8d34-4c9e-4552-b21f-37b9760c8efa" />

## 작업 후
<img width="596" height="200" alt="image" src="https://github.com/user-attachments/assets/f9bf6f7d-1e39-49b0-87dc-768aabff2711" />
